### PR TITLE
Simplify dependencies

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/olix0r/kubert"
 rust-version = "1.56.1"
 
 [features]
-client = ["kube/client"]
+client = ["kube-client"]
 # TODO controller = ["client", "kube/runtime"]
 log = ["tracing-subscriber"]
 # TODO runtime = ["clap", "drain", "log", "tokio/signal"]
@@ -38,24 +38,28 @@ features = [
 
 [dependencies]
 drain = { version = "0.1.0", optional = true, default-features = false }
-hyper = { version = "0.14.0", optional = true, default-features = false }
-kube = { version = "0.69.1", default-features = false }
-rustls = { version = "0.20", optional = true, default-features = false }
-rustls-pemfile = { version = "0.3", optional = true }
-thiserror = "1.0.0"
-tokio = { version = "1.6", default-features = false }
-tokio-rustls = { version = "0.23", optional = true, default-features = false }
-tower-service = { version = "0.3", optional = true }
-tracing = "0.1"
+hyper = { version = "0.14.17", optional = true, default-features = false }
+rustls-pemfile = { version = "0.3.0", optional = true }
+thiserror = "1.0.30"
+tokio = { version = "1.17.0", default-features = false }
+tokio-rustls = { version = "0.23.2", optional = true, default-features = false }
+tower-service = { version = "0.3.1", optional = true }
+tracing = "0.1.31"
 
 [dependencies.clap]
-version = "3.0.0"
+version = "3.1.0"
 optional = true
 default-features = false
 features = ["derive", "std"]
 
+[dependencies.kube-client]
+version = "0.69.1"
+optional = true
+default-features = false
+features = ["client", "config"]
+
 [dependencies.tracing-subscriber]
-version = "0.3"
+version = "0.3.9"
 optional = true
 default-features = false
 features = [
@@ -67,4 +71,4 @@ features = [
 ]
 
 [dev-dependencies]
-k8s-openapi = { version = "0.14", default-features = false, features = ["v1_23"] }
+k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_23"] }

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -1,4 +1,4 @@
-pub use kube::Client;
+pub use kube_client::Client;
 use thiserror::Error;
 
 // TODO configure a --kubeconfig
@@ -13,19 +13,19 @@ pub struct ClientArgs {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
-    Kubeconfig(#[from] kube::config::KubeconfigError),
+    Kubeconfig(#[from] kube_client::config::KubeconfigError),
 
     #[error(transparent)]
-    Client(#[from] kube::Error),
+    Client(#[from] kube_client::Error),
 }
 
 impl ClientArgs {
     pub async fn try_client(self) -> Result<Client, Error> {
-        let c = kube::config::KubeConfigOptions {
+        let c = kube_client::config::KubeConfigOptions {
             context: self.context,
             ..Default::default()
         };
-        kube::Config::from_kubeconfig(&c)
+        kube_client::Config::from_kubeconfig(&c)
             .await?
             .try_into()
             .map_err(Error::from)


### PR DESCRIPTION
Replace the `kube` dependency with `kube-client`, which is used only by
the `client` feature.

Update Cargo.toml to express patch versions, since compilation failed on
minimal versions.