### PR TITLE
Add docs for all public types

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -28,7 +28,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   clippy:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
       image: docker://rust:1.58.1
@@ -41,3 +41,18 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: cargo fetch
       - run: cargo clippy --all-features --all-targets --message-format=json | cargo-action-fmt
+
+  docs:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.58.1-buster
+    steps:
+      - run: |
+          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
+          chmod 755 /usr/local/bin/cargo-action-fmt
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: cargo fetch
+      - run: cargo doc --all-features --workspace --no-deps --message-format=json | cargo-action-fmt
+
+

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -1,33 +1,52 @@
-pub use kube_client::Client;
+//! Utilities for configuring a [`kube_client::Client`] from the command line
+
+pub use kube_client::*;
 use thiserror::Error;
 
+/// Configures a Kubernetes client
 // TODO configure a --kubeconfig
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub struct ClientArgs {
-    // Kubernetes context.
+    /// The name of the kubeconfig cluster to use
+    #[cfg_attr(feature = "clap", clap(long))]
+    pub cluster: Option<String>,
+
+    /// The name of the kubeconfig context to use
     #[cfg_attr(feature = "clap", clap(long))]
     pub context: Option<String>,
+
+    /// The name of the kubeconfig user to use
+    #[cfg_attr(feature = "clap", clap(long))]
+    pub user: Option<String>,
 }
 
+/// Indicates an error occurred while configuring the Kubernetes client
 #[derive(Debug, Error)]
-pub enum Error {
+pub enum ConfigError {
+    /// Indicates that the kubeconfig file could not be read
     #[error(transparent)]
-    Kubeconfig(#[from] kube_client::config::KubeconfigError),
+    Kubeconfig(#[from] config::KubeconfigError),
 
+    /// Indicates that the client could not be initialized
     #[error(transparent)]
-    Client(#[from] kube_client::Error),
+    Client(#[from] Error),
 }
 
 impl ClientArgs {
-    pub async fn try_client(self) -> Result<Client, Error> {
+    /// Initializes a Kubernetes client
+    ///
+    /// This will respect the `$KUBECONFIG` environment variable, but otherwise default to
+    /// `~/.kube/config`. The _current-context_ is used unless `context` is set.
+    pub async fn try_client(self) -> Result<Client, ConfigError> {
         let c = kube_client::config::KubeConfigOptions {
             context: self.context,
-            ..Default::default()
+            cluster: self.cluster,
+            user: self.user,
         };
         kube_client::Config::from_kubeconfig(&c)
             .await?
             .try_into()
-            .map_err(Error::from)
+            .map_err(Into::into)
     }
 }

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -1,8 +1,12 @@
-#![deny(warnings, rust_2018_idioms)]
+//! Utilities for Kubernetes controllers built on [`kube`]
+//!
+//! [`kube`]: https://github.com/kube-rs/kube-rs
+
+#![deny(warnings, rust_2018_idioms, missing_docs)]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "client")]
-mod client;
+pub mod client;
 
 #[cfg(all(feature = "client"))]
 pub use self::client::ClientArgs;

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -1,14 +1,22 @@
+//! Configures the global default tracing subscriber
+
 use thiserror::Error;
 use tracing_subscriber::util::TryInitError;
 
 pub use tracing_subscriber::EnvFilter;
 
+/// Configures whether logs should be emitted in plaintext (the default) or as JSON-encoded
+/// messages
 #[derive(Clone, Debug)]
 pub enum LogFormat {
-    Json,
+    /// The default plaintext format
     Plain,
+
+    /// The JSON-encoded format
+    Json,
 }
 
+/// Indicates that an invalid log format was specified
 #[derive(Debug, Error)]
 #[error("invalid log level: {0} must be 'plain' or 'json'")]
 pub struct InvalidLogFormat(String);
@@ -34,6 +42,11 @@ impl std::str::FromStr for LogFormat {
 }
 
 impl LogFormat {
+    /// Attempts to configure the global default tracing subscriber in the current scope, returning
+    /// an error if one is already set
+    ///
+    /// This method returns an error if a global default subscriber has already been set, or if a
+    /// `log` logger has already been set.
     pub fn try_init(self, filter: EnvFilter) -> Result<(), TryInitError> {
         use tracing_subscriber::prelude::*;
 

--- a/kubert/src/shutdown.rs
+++ b/kubert/src/shutdown.rs
@@ -1,24 +1,26 @@
+//! Drives graceful shutdown when the process receives a signal.
+
 use tokio::signal::unix::{signal, SignalKind};
 use tracing::debug;
 
 pub use drain::Watch;
 
-/// Drives shutdown by watching signals.
+/// Drives shutdown by watching signals
 #[derive(Debug)]
 #[must_use = "call `Shutdown::on_signal` to await a signal"]
 pub struct Shutdown(drain::Signal);
 
-/// Indicates whether shutdown completed gracefully or was forced by a second signal.
+/// Indicates whether shutdown completed gracefully or was forced by a second signal
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Completion {
-    /// Indicates that shutdown completed gracefully.
+    /// Indicates that shutdown completed gracefully
     Graceful,
 
-    /// Indicates that shutdown did not complete gracefully.
+    /// Indicates that shutdown did not complete gracefully
     Aborted,
 }
 
-/// Creates a shutdown channel.
+/// Creates a shutdown channel
 ///
 /// [`Shutdown`] watches for `SIGINT` and `SIGTERM` signals. When a signal is received, [`Watch`]
 /// instances are notifed and, when all watches are dropped, the shutdown is completed. If a second
@@ -31,11 +33,12 @@ pub fn channel() -> (Shutdown, Watch) {
 }
 
 impl Shutdown {
-    /// Watches for signals and drives shutdown.
+    /// Watches for signals and drives shutdown
     ///
-    /// I
+    /// When a `SIGINT` or `SIGTERM` signal is received, the shutdown is initiated, notifying all
+    /// [`Watch`] instances. When all watches are dropped, the shutdown is completed.
     ///
-    /// If a second signal is received while waiting for the process to terminate, this future
+    /// If a second signal is received while waiting for watches to be dropped, this future
     /// completes immediately and [`Completion::Aborted`] is returned.
     ///
     /// An error is returned when signal registration fails.
@@ -73,10 +76,12 @@ impl Shutdown {
 }
 
 impl Completion {
+    /// Returns `true` if the shutdown completed gracefully
     pub fn is_graceful(&self) -> bool {
         matches!(self, Completion::Graceful)
     }
 
+    /// Returns `true` if the shutdown was aborted
     pub fn is_aborted(&self) -> bool {
         matches!(self, Completion::Aborted)
     }


### PR DESCRIPTION
Also add `--cluster` and `--user` flags to the `ClientArgs` for
completeness.

This change adds a lint check to ensure docs are valid, too.