### PR TITLE
client: Fallback to using the in-cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kubert
 
+![kubert](https://user-images.githubusercontent.com/240738/154825590-5a94ca46-a453-4037-a738-26663b2c8630.png)
+
 Rust Kubernetes runtime helpers. Based on [`kube-rs`][krs].
 
 [krs]: https://github.com/kube-rs/kube-rs


### PR DESCRIPTION
This change replicates the behavior of `kube::Client::try_default` so
in-cluster configs are tried when a kubeconfig can not be found. The
fallback is only attempted when CLI flags do not configure kubeconfig
parameters.