### PR TITLE
Add a requeue channel

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,10 @@
-name: lints
+name: lint
 
 on:
   pull_request:
     paths:
       - '**/*.rs'
-      - .github/workflows/lints.yml
+      - .github/workflows/lint.yml
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,7 @@ jobs:
           chmod 755 /usr/local/bin/cargo-action-fmt
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: cargo fetch
-      - run: cargo test --no-run --frozen --workspace --all-features --message-format=json | cargo-action-fmt
-      - run: cargo test          --frozen --workspace --all-features --message-format=json | cargo-action-fmt
+      - name: cargo test --no-run
+        run: cargo test --frozen --workspace --all-features --no-run --message-format=json | cargo-action-fmt
+      - name: cargo test
+        run: cargo test --frozen --workspace --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - '**/*.rs'
+      - .github/workflows/test.yml
+
+permissions:
+  contents: read
+
+env:
+  CARGO_ACTION_FMT_VERSION: v0.1.3
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.58.1
+    steps:
+      - name: install cargo-action-fmt
+        run: |
+          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
+          chmod 755 /usr/local/bin/cargo-action-fmt
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: cargo fetch
+      - run: cargo test --no-run --frozen --workspace --all-features --message-format=json | cargo-action-fmt
+      - run: cargo test          --frozen --workspace --all-features --message-format=json | cargo-action-fmt

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,7 @@ ignore = [
 
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "ISC", "MIT"]
+allow = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT"]
 deny = []
 copyleft = "deny"
 allow-osi-fsf-free = "neither"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 client = ["kube-client", "thiserror"]
 # TODO controller = ["client", "kube/runtime"]
 log = ["thiserror", "tracing-subscriber"]
-requeue = ["futures", "kube-core", "kube-runtime", "tokio-util/time"]
+requeue = ["futures", "kube-core", "kube-runtime", "tokio/macros", "tokio/sync", "tokio-util/time"]
 # TODO runtime = ["clap", "drain", "log", "tokio/signal"]
 server = [
     "drain",

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 client = ["kube-client", "thiserror"]
 # TODO controller = ["client", "kube/runtime"]
 log = ["thiserror", "tracing-subscriber"]
+requeue = ["futures", "kube-core", "kube-runtime", "tokio-util/time"]
 # TODO runtime = ["clap", "drain", "log", "tokio/signal"]
 server = [
     "drain",
@@ -44,10 +45,12 @@ features = [
 
 [dependencies]
 drain = { version = "0.1.0", optional = true, default-features = false }
+futures = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 rustls-pemfile = { version = "0.3.0", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }
+tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.23.2", optional = true, default-features = false }
 tower-service = { version = "0.3.1", optional = true }
 tracing = "0.1.31"
@@ -63,6 +66,16 @@ version = "0.69.1"
 optional = true
 default-features = false
 features = ["client", "config"]
+
+[dependencies.kube-core]
+version = "0.69.1"
+optional = true
+default-features = false
+
+[dependencies.kube-runtime]
+version = "0.69.1"
+optional = true
+default-features = false
 
 [dependencies.tracing-subscriber]
 version = "0.3.9"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 client = ["kube-client", "thiserror"]
 # TODO controller = ["client", "kube/runtime"]
 log = ["thiserror", "tracing-subscriber"]
-requeue = ["futures", "kube-core", "kube-runtime", "tokio/macros", "tokio/sync", "tokio-util/time"]
+requeue = ["futures", "tokio/macros", "tokio/sync", "tokio-util/time"]
 # TODO runtime = ["clap", "drain", "log", "tokio/signal"]
 server = [
     "drain",
@@ -90,6 +90,7 @@ features = [
 ]
 
 [dev-dependencies]
+kube = { version = "0.69.1", default-features = false, features = ["runtime"] }
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_23"] }
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
 tokio-stream = "0.1.8"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 client = ["kube-client", "thiserror"]
 # TODO controller = ["client", "kube/runtime"]
 log = ["thiserror", "tracing-subscriber"]
-requeue = ["futures", "tokio/macros", "tokio/sync", "tokio-util/time"]
+requeue = ["futures-core", "tokio/macros", "tokio/sync", "tokio-util/time"]
 # TODO runtime = ["clap", "drain", "log", "tokio/signal"]
 server = [
     "drain",
@@ -45,7 +45,7 @@ features = [
 
 [dependencies]
 drain = { version = "0.1.0", optional = true, default-features = false }
-futures = { version = "0.3", optional = true, default-features = false }
+futures-core = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 rustls-pemfile = { version = "0.3.0", optional = true }
 thiserror = { version = "1.0.30", optional = true }
@@ -93,7 +93,6 @@ features = [
 kube = { version = "0.69.1", default-features = false, features = ["runtime"] }
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_23"] }
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
-tokio-stream = "0.1.8"
 tokio-test = "0.4"
 
 [dev-dependencies.tokio]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -91,3 +91,11 @@ features = [
 
 [dev-dependencies]
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["v1_23"] }
+tracing-subscriber = { version = "0.3", features = ["ansi"] }
+tokio-stream = "0.1.8"
+tokio-test = "0.4"
+
+[dev-dependencies.tokio]
+version = "1.17"
+default-features = false
+features = ["macros", "test-util"]

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -22,6 +22,14 @@ pub mod log;
 #[cfg_attr(docsrs, doc(cfg(any(feature = "shutdown"))))]
 pub mod shutdown;
 
+#[cfg(feature = "requeue")]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "requeue"))))]
+pub mod requeue;
+
+#[cfg(all(feature = "requeue"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "requeue"))))]
+pub use self::requeue::Requeue;
+
 #[cfg(feature = "server")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "shutdown"))))]
 pub mod server;

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -26,10 +26,6 @@ pub mod shutdown;
 #[cfg_attr(docsrs, doc(cfg(any(feature = "requeue"))))]
 pub mod requeue;
 
-#[cfg(all(feature = "requeue"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "requeue"))))]
-pub use self::requeue::Requeue;
-
 #[cfg(feature = "server")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "shutdown"))))]
 pub mod server;

--- a/kubert/src/requeue.rs
+++ b/kubert/src/requeue.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use futures::prelude::*;
 use kube_core::Resource;
 use kube_runtime::reflector::ObjectRef;
@@ -5,45 +7,98 @@ use std::{
     collections::{hash_map, HashMap},
     hash::Hash,
 };
-use tokio::time::Duration;
+use tokio::{
+    sync::mpsc::{self, error::SendError},
+    time::{Duration, Instant},
+};
 use tokio_util::time::{delay_queue, DelayQueue};
 
-pub struct Requeue<T>
-where
-    T: Resource,
-    T::DynamicType: PartialEq + Eq + Hash + Clone,
-{
-    q: DelayQueue<ObjectRef<T>>,
-    keys: HashMap<ObjectRef<T>, delay_queue::Key>,
-    sleep: tokio::time::Duration,
+pub struct Sender<T: Resource> {
+    tx: mpsc::Sender<(ObjectRef<T>, Instant)>,
 }
 
-impl<T> Requeue<T>
+pub struct Receiver<T>
 where
     T: Resource,
     T::DynamicType: PartialEq + Eq + Hash + Clone,
 {
-    pub fn new(sleep: Duration) -> Self {
-        Self {
-            q: DelayQueue::new(),
-            keys: HashMap::default(),
-            sleep,
-        }
-    }
+    rx: mpsc::Receiver<(ObjectRef<T>, Instant)>,
+    rx_closed: bool,
+    q: DelayQueue<ObjectRef<T>>,
+    pending: HashMap<ObjectRef<T>, delay_queue::Key>,
+}
 
-    pub fn insert(&mut self, key: ObjectRef<T>) {
-        match self.keys.entry(key) {
-            hash_map::Entry::Occupied(v) => self.q.reset(v.get(), self.sleep),
-            hash_map::Entry::Vacant(v) => {
-                let key = self.q.insert(v.key().clone(), self.sleep);
-                v.insert(key);
+pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>)
+where
+    T: Resource,
+    T::DynamicType: PartialEq + Eq + Hash + Clone,
+{
+    let (tx, rx) = mpsc::channel(capacity);
+    let tx = Sender { tx };
+    let rx = Receiver {
+        rx,
+        rx_closed: false,
+        q: DelayQueue::new(),
+        pending: HashMap::new(),
+    };
+    (tx, rx)
+}
+
+impl<T> Receiver<T>
+where
+    T: Resource,
+    T::DynamicType: PartialEq + Eq + Hash + Clone,
+{
+    pub async fn recv(&mut self) -> Option<ObjectRef<T>> {
+        while !(self.rx_closed && self.pending.is_empty()) {
+            tokio::select! {
+                k = self.rx.recv(), if !self.rx_closed => match k {
+                    Some((k, at)) => match self.pending.entry(k) {
+                        hash_map::Entry::Occupied(ent) => {
+                            self.q.reset_at(ent.get(), at);
+                        }
+                        hash_map::Entry::Vacant(slot) => {
+                            let key = self.q.insert_at(slot.key().clone(), at);
+                            slot.insert(key);
+                        }
+                    },
+                    None => {
+                        self.rx_closed = true;
+                    },
+                },
+
+                exp = self.q.next() => {
+                    if let Some(exp) = exp {
+                        let k = exp.into_inner();
+                        self.pending.remove(&k);
+                        return Some(k);
+                    }
+                }
             }
-        };
+        }
+
+        None
+    }
+}
+
+impl<T: Resource> Sender<T> {
+    pub async fn closed(&self) {
+        self.tx.closed().await
     }
 
-    pub async fn next(&mut self) -> Option<ObjectRef<T>> {
-        let k = self.q.next().await?.into_inner();
-        self.keys.remove(&k);
-        Some(k)
+    pub async fn requeue(
+        &self,
+        key: ObjectRef<T>,
+        wait: Duration,
+    ) -> Result<(), SendError<(ObjectRef<T>, Instant)>> {
+        self.requeue_at(key, Instant::now() + wait).await
+    }
+
+    pub async fn requeue_at(
+        &self,
+        key: ObjectRef<T>,
+        time: Instant,
+    ) -> Result<(), SendError<(ObjectRef<T>, Instant)>> {
+        self.tx.send((key, time)).await
     }
 }

--- a/kubert/src/requeue.rs
+++ b/kubert/src/requeue.rs
@@ -1,7 +1,7 @@
 //! A bounded, delayed, multi-producer, single-consumer queue for deferring work in response to
 //! scheduler updates.
 
-use futures::prelude::*;
+use futures::stream::StreamExt;
 use kube_core::Resource;
 use kube_runtime::reflector::ObjectRef;
 use std::{

--- a/kubert/src/requeue.rs
+++ b/kubert/src/requeue.rs
@@ -51,32 +51,38 @@ where
 {
     pub async fn recv(&mut self) -> Option<ObjectRef<T>> {
         while !(self.rx_closed && self.pending.is_empty()) {
+            tracing::trace!(rx.closed = self.rx_closed, pending = self.pending.len());
             tokio::select! {
-                k = self.rx.recv(), if !self.rx_closed => match k {
+                item = self.rx.recv(), if !self.rx_closed => match item {
                     Some((k, at)) => match self.pending.entry(k) {
                         hash_map::Entry::Occupied(ent) => {
+                            tracing::trace!(name = %ent.key().name, "resetting");
                             self.q.reset_at(ent.get(), at);
                         }
                         hash_map::Entry::Vacant(slot) => {
+                            tracing::trace!(name = %slot.key().name, "inserting");
                             let key = self.q.insert_at(slot.key().clone(), at);
                             slot.insert(key);
                         }
                     },
                     None => {
+                        tracing::trace!("receiver closed");
                         self.rx_closed = true;
-                    },
+                    }
                 },
 
-                exp = self.q.next() => {
+                exp = self.q.next(), if !self.pending.is_empty() => {
                     if let Some(exp) = exp {
-                        let k = exp.into_inner();
-                        self.pending.remove(&k);
-                        return Some(k);
+                        let key = exp.into_inner();
+                        tracing::trace!(name = %key.name, "dequeued");
+                        self.pending.remove(&key);
+                        return Some(key);
                     }
                 }
             }
         }
 
+        tracing::trace!("complete");
         None
     }
 }
@@ -108,5 +114,141 @@ impl<T: Resource> Clone for Sender<T> {
         Self {
             tx: self.tx.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    pub use super::*;
+    use k8s_openapi::api::core::v1::Pod;
+    use tokio::time;
+    use tokio_stream::wrappers::ReceiverStream;
+    use tokio_test::{assert_pending, assert_ready, task};
+    use tracing::{info_span, Instrument};
+
+    fn spawn_channel(
+        capacity: usize,
+    ) -> (Sender<Pod>, task::Spawn<ReceiverStream<ObjectRef<Pod>>>) {
+        // Spawn a (mocked) task that reads from the receiver and updates a counter.
+        let (rqtx, mut rqrx) = channel::<Pod>(capacity);
+        let (tx, rx) = mpsc::channel(capacity);
+        let t0 = time::Instant::now();
+        tokio::spawn(
+            async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = tx.closed() => {
+                            tracing::trace!("test sender closed");
+                            break;
+                        }
+                        p = rqrx.recv() => match p {
+                            None => {
+                                tracing::trace!("requeue receiver closed");
+                                break;
+                            }
+                            Some(pod) => {
+                                tracing::debug!(?pod, "dequeued");
+                                if tx.send(pod).await.is_err() {
+                                    break;
+                                }
+                                tracing::trace!("pod sent");
+                            }
+                        }
+                    }
+                }
+                tracing::debug!(uptime = ?time::Instant::now() - t0, "channel complete")
+            }
+            .instrument(info_span!("requeue worker")),
+        );
+        (rqtx, task::spawn(ReceiverStream::new(rx)))
+    }
+
+    fn init_tracing() -> tracing::subscriber::DefaultGuard {
+        tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .with_test_writer()
+                .with_max_level(tracing::Level::TRACE)
+                .finish(),
+        )
+    }
+
+    async fn sleep(d: Duration) {
+        let t0 = time::Instant::now();
+        time::sleep(d).await;
+        tracing::trace!(duration = ?d, ?t0, now = ?time::Instant::now(), "slept")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn delays() {
+        let _tracing = init_tracing();
+        time::pause();
+        let (tx, mut rx) = spawn_channel(1);
+
+        let pod_a = ObjectRef::new("pod-a").within("default");
+        tx.requeue(pod_a.clone(), Duration::from_secs(10))
+            .await
+            .expect("must send");
+        assert_pending!(rx.poll_next());
+
+        sleep(Duration::from_millis(10001)).await;
+        assert_eq!(
+            assert_ready!(rx.poll_next()).expect("stream must not end"),
+            pod_a
+        );
+        assert_pending!(rx.poll_next());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drains_after_sender_dropped() {
+        let _tracing = init_tracing();
+        time::pause();
+        let (tx, mut rx) = spawn_channel(1);
+
+        let pod_a = ObjectRef::new("pod-a").within("default");
+        tx.requeue(pod_a.clone(), Duration::from_secs(10))
+            .await
+            .expect("must send");
+        drop(tx);
+        assert_pending!(rx.poll_next());
+
+        sleep(Duration::from_secs(11)).await;
+        assert_eq!(
+            assert_ready!(rx.poll_next()).expect("stream must not end"),
+            pod_a
+        );
+        assert!(assert_ready!(rx.poll_next()).is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resets() {
+        let _tracing = init_tracing();
+        time::pause();
+        let (tx, mut rx) = spawn_channel(1);
+
+        // Requeue a pod
+        let pod_a = ObjectRef::new("pod-a").within("default");
+        tx.requeue(pod_a.clone(), Duration::from_secs(10))
+            .await
+            .expect("must send");
+        assert_pending!(rx.poll_next());
+
+        // Re-requeue the same pod after 9s.
+        sleep(Duration::from_secs(9)).await;
+        tx.requeue(pod_a.clone(), Duration::from_secs(10))
+            .await
+            .expect("must send");
+
+        // Wait until the first requeue would timeout and check that it has not been sent.
+        sleep(Duration::from_millis(1001)).await;
+        assert_pending!(rx.poll_next());
+
+        // Wait until the second requeue would timeout and check that it has been sent.
+        sleep(Duration::from_secs(9)).await;
+        assert_eq!(
+            assert_ready!(rx.poll_next()).expect("stream must not end"),
+            pod_a
+        );
+        assert_pending!(rx.poll_next());
     }
 }

--- a/kubert/src/requeue.rs
+++ b/kubert/src/requeue.rs
@@ -102,3 +102,11 @@ impl<T: Resource> Sender<T> {
         self.tx.send((key, time)).await
     }
 }
+
+impl<T: Resource> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+}

--- a/kubert/src/requeue.rs
+++ b/kubert/src/requeue.rs
@@ -1,0 +1,49 @@
+use futures::prelude::*;
+use kube_core::Resource;
+use kube_runtime::reflector::ObjectRef;
+use std::{
+    collections::{hash_map, HashMap},
+    hash::Hash,
+};
+use tokio::time::Duration;
+use tokio_util::time::{delay_queue, DelayQueue};
+
+pub struct Requeue<T>
+where
+    T: Resource,
+    T::DynamicType: PartialEq + Eq + Hash + Clone,
+{
+    q: DelayQueue<ObjectRef<T>>,
+    keys: HashMap<ObjectRef<T>, delay_queue::Key>,
+    sleep: tokio::time::Duration,
+}
+
+impl<T> Requeue<T>
+where
+    T: Resource,
+    T::DynamicType: PartialEq + Eq + Hash + Clone,
+{
+    pub fn new(sleep: Duration) -> Self {
+        Self {
+            q: DelayQueue::new(),
+            keys: HashMap::default(),
+            sleep,
+        }
+    }
+
+    pub fn insert(&mut self, key: ObjectRef<T>) {
+        match self.keys.entry(key) {
+            hash_map::Entry::Occupied(v) => self.q.reset(v.get(), self.sleep),
+            hash_map::Entry::Vacant(v) => {
+                let key = self.q.insert(v.key().clone(), self.sleep);
+                v.insert(key);
+            }
+        };
+    }
+
+    pub async fn next(&mut self) -> Option<ObjectRef<T>> {
+        let k = self.q.next().await?.into_inner();
+        self.keys.remove(&k);
+        Some(k)
+    }
+}


### PR DESCRIPTION
    As a controller processes events, it may not be able to act successfully
    on these events: there may be a transient problem when writing to the
    API server, or the system may not be in a converged state and it may be
    necessary to reprocess the update at a later time.
    
    The `requeue` channel provides a bounded, multi-producer/single-
    consumer, delay-queue channel. Applications can use this channel to
    reschedule updates for a later time. While this is especially useful for
    controllers, this channel is not inherently tied to Kubernetes in any
    way.