### PR TITLE
server: Read PKSC8 private keys

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -4,7 +4,9 @@
 //! Unlike a normal `hyper` server, this server reloads its TLS credentials for each connection to
 //! support certificate rotation.
 
-use std::{convert::Infallible, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    convert::Infallible, io::BufReader, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc,
+};
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{rustls, TlsAcceptor};
@@ -298,7 +300,7 @@ impl TlsCertPath {
     async fn load_certs(&self) -> std::io::Result<Vec<rustls::Certificate>> {
         // Open certificate file.
         let pem = tokio::fs::read(&self.0).await?;
-        let mut reader = std::io::BufReader::new(pem.as_slice());
+        let mut reader = BufReader::new(pem.as_slice());
 
         // Load and return certificate.
         let certs = rustls_pemfile::certs(&mut reader)?;
@@ -320,10 +322,10 @@ impl TlsKeyPath {
     async fn load_private_key(&self) -> std::io::Result<rustls::PrivateKey> {
         // Open keyfile.
         let pem = tokio::fs::read(&self.0).await?;
-        let mut reader = std::io::BufReader::new(pem.as_slice());
 
         // Load and return a single private key.
-        let keys = rustls_pemfile::rsa_private_keys(&mut reader)?;
+        let keys = rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(pem.as_slice()))
+            .or_else(|_| rustls_pemfile::rsa_private_keys(&mut BufReader::new(pem.as_slice())))?;
         if keys.len() != 1 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -4,9 +4,7 @@
 //! Unlike a normal `hyper` server, this server reloads its TLS credentials for each connection to
 //! support certificate rotation.
 
-use std::{
-    convert::Infallible, io::BufReader, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc,
-};
+use std::{convert::Infallible, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{rustls, TlsAcceptor};
@@ -300,10 +298,9 @@ impl TlsCertPath {
     async fn load_certs(&self) -> std::io::Result<Vec<rustls::Certificate>> {
         // Open certificate file.
         let pem = tokio::fs::read(&self.0).await?;
-        let mut reader = BufReader::new(pem.as_slice());
 
         // Load and return certificate.
-        let certs = rustls_pemfile::certs(&mut reader)?;
+        let certs = rustls_pemfile::certs(&mut pem.as_slice())?;
         Ok(certs.into_iter().map(rustls::Certificate).collect())
     }
 }
@@ -324,8 +321,8 @@ impl TlsKeyPath {
         let pem = tokio::fs::read(&self.0).await?;
 
         // Load and return a single private key.
-        let keys = rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(pem.as_slice()))
-            .or_else(|_| rustls_pemfile::rsa_private_keys(&mut BufReader::new(pem.as_slice())))?;
+        let keys = rustls_pemfile::pkcs8_private_keys(&mut pem.as_slice())
+            .or_else(|_| rustls_pemfile::rsa_private_keys(&mut pem.as_slice()))?;
         if keys.len() != 1 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,


### PR DESCRIPTION
Currently the server only attempts to parse RSA private keys. This
change updates the server to first attempt to read PKSC8 private keys
before attempting to parse the key file as RSA.