### PR TITLE
Add a simple example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,6 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: cargo fetch
       - name: cargo test --no-run
-        run: cargo test --frozen --workspace --all-features --no-run --message-format=json | cargo-action-fmt
+        run: cargo test --frozen --workspace --all-targets --all-features --no-run --message-format=json | cargo-action-fmt
       - name: cargo test
-        run: cargo test --frozen --workspace --all-features
+        run: cargo test --frozen --workspace --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 default-members = ["kubert"]
-members = ["kubert"]
+members = [
+    "kubert",
+    "examples",
+]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ controllers for [Linkerd](https://github.com/linkerd/linkerd2). It doesn't try t
 `kube`--though it does reduce boilerplate around initializing watches and caches (reflectors); and
 it expects you to schedule work via the `tokio` runtime.
 
+## Examples
+
+This repository includes a simple [example application](./examples) that demonstrates how to use a
+`kubert::Runtime`.
+
+Other examples include:
+* [Linkerd2 policy controller](https://github.com/linkerd/linkerd2/blob/d4543cd86e427b241ce961b50dd83b1738c0b069/policy-controller/src/main.rs)
+
 ## Status
 
 This crate is still fairly experimental, though it's based on production code from Linkerd; and we

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,9 @@ highlight = "all"
 deny = []
 skip-tree = []
 skip = [
+    # Waiting on kube-runtime
+    { name = "parking_lot", version = "0.11" },
+    { name = "parking_lot_core", version = "0.8" },
     # Waiting on h2, kube-client
     { name = "tokio-util", version = "0.6.9" },
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "kubert-examples"
+version = "0.1.0"
+publish = false
+edition = "2021"
+license = "Apache-2.0"
+rust-version = "1.56.1"
+
+[package.metadata.release]
+release = false
+
+[dev-dependencies]
+anyhow = "1"
+clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
+futures = { version = "0.3", default-features = false }
+k8s-openapi = { version = "0.14", default-features = false, features = ["v1_23"] }
+tracing = "0.1"
+
+[dev-dependencies.kube]
+version = "0.69.1"
+default-features = false
+features = [
+    "client",
+    "derive",
+    "native-tls",
+    "runtime",
+]
+
+[dev-dependencies.kubert]
+path = "../kubert"
+version = "0.3.0"
+default-features = false
+features = [
+    "clap",
+    "runtime",
+]
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["macros", "parking_lot", "rt", "rt-multi-thread"]
+
+[[example]]
+name = "watch-pods"
+path = "watch_pods.rs"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,35 @@
+# kubert examples
+
+## [`watch-pods`](./watch_pods.rs)
+
+A simple Kubernetes example that watches for pod updates and logs them.
+
+```text
+:; cargo run --example watch-pods -p kubert-examples -- --selector=linkerd.io/control-plane-ns
+   Compiling kubert-examples v0.1.0 (/workspaces/kubert/examples)
+    Finished dev [unoptimized + debuginfo] target(s) in 7.23s
+     Running `target/debug/examples/watch-pods --selector=linkerd.io/control-plane-ns`
+2022-03-02T03:16:12.370463Z  INFO pods: watch_pods: added namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:12.380229Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:12.407258Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:12.464362Z  INFO pods: watch_pods: added namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:12.486658Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:12.509484Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:12.515244Z  INFO pods: watch_pods: added namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:12.524817Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:12.547041Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:13.592621Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:13.732357Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:13.762360Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:14.738187Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:15.740861Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:20.602560Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:20.616147Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:21.606533Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-proxy-injector-6c57f585c4-n674t
+2022-03-02T03:16:22.396102Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-identity-7d9c4cd9b8-kpwql
+2022-03-02T03:16:22.744278Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:22.759241Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:23.746871Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:23.760010Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+2022-03-02T03:16:23.773358Z  INFO pods: watch_pods: updated namespace=linkerd name=linkerd-destination-5b6fc7cb9-hn9hr
+```

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -1,0 +1,127 @@
+#![deny(warnings, rust_2018_idioms)]
+#![forbid(unsafe_code)]
+
+use anyhow::{bail, Result};
+use clap::Parser;
+use futures::prelude::*;
+use k8s_openapi::api::core::v1::Pod;
+use kube::{api::ListParams, runtime::watcher::Event, ResourceExt};
+use tracing::Instrument;
+
+#[derive(Parser)]
+#[clap(version)]
+struct Args {
+    #[clap(
+        long,
+        env = "KUBERT_EXAMPLE_LOG",
+        default_value = "watch_pods=info,warn"
+    )]
+    log_level: kubert::LogFilter,
+
+    #[clap(long, default_value = "plain")]
+    log_format: kubert::LogFormat,
+
+    #[clap(flatten)]
+    client: kubert::ClientArgs,
+
+    #[clap(flatten)]
+    admin: kubert::AdminArgs,
+
+    #[clap(long, short = 'l')]
+    selector: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let Args {
+        log_level,
+        log_format,
+        client,
+        admin,
+        selector,
+    } = Args::parse();
+
+    // Configure a runtime with:
+    // - a Kubernetes client
+    // - an admin server with /live and /ready endpoints
+    // - a tracing (logging) subscriber
+    let mut runtime = kubert::Runtime::builder()
+        .with_log(log_level, log_format)
+        .with_admin(admin)
+        .with_client(client)
+        .build()
+        .await?;
+
+    // Watch all pods and print changes.
+    //
+    // This stream completes when shutdown is signaled; and the admin endpoint does not return ready
+    // until the first update is received.
+    tracing::debug!(?selector);
+    let params = selector
+        .iter()
+        .fold(ListParams::default(), |p, l| p.labels(&l));
+    let pods = runtime.watch_all::<Pod>(params);
+    tokio::spawn(
+        async move {
+            tokio::pin!(pods);
+
+            // Keep a list of all known pods so we can identify new and deleted pods on restart.
+            // The watch will restart roughly every 5 minutes.
+            let mut known = std::collections::HashSet::<(String, String)>::new();
+            while let Some(ev) = pods.next().await {
+                tracing::trace!(?ev);
+                match ev {
+                    Event::Restarted(pods) => {
+                        tracing::debug!(pods = %pods.len(), "restarted");
+                        let mut new = std::collections::HashSet::new();
+                        for pod in pods.into_iter() {
+                            let namespace = pod.namespace().unwrap();
+                            let name = pod.name();
+                            let k = (namespace.clone(), name.clone());
+                            if !known.contains(&k) {
+                                tracing::info!(%namespace, %name, "added")
+                            } else {
+                                tracing::debug!(%namespace, %name, "already exists")
+                            }
+                            new.insert(k);
+                        }
+                        for (namespace, name) in known.into_iter() {
+                            if !new.contains(&(namespace.clone(), name.clone())) {
+                                tracing::info!(%namespace, %name, "deleted")
+                            }
+                        }
+                        known = new;
+                    }
+
+                    Event::Applied(pod) => {
+                        let namespace = pod.namespace().unwrap();
+                        let name = pod.name();
+                        if known.insert((namespace.clone(), name.clone())) {
+                            tracing::info!(%namespace, %name, "added");
+                        } else {
+                            tracing::info!(%namespace, %name, "updated");
+                        }
+                    }
+
+                    Event::Deleted(pod) => {
+                        let namespace = pod.namespace().unwrap();
+                        let name = pod.name();
+                        tracing::info!(%namespace, %name, "deleted");
+                        known.remove(&(namespace, name));
+                    }
+                }
+            }
+            tracing::debug!("completed");
+        }
+        .instrument(tracing::info_span!("pods")),
+    );
+
+    // Block the main thread on the shutdown signal. This won't complete until the watch stream
+    // stops (after pending Pod updates are logged). If a second signal is received before the watch
+    // stream completes, the future fails.
+    if runtime.run().await.is_err() {
+        bail!("aborted");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This change adds a simple `watch-pods` example that uses
`kubert::Runtime` to build a simple application that logs pod updates.

Closes #11