### PR TITLE
server: Add diganostic logging

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -396,6 +396,11 @@ impl<S> Runtime<S> {
 
 #[cfg(feature = "server")]
 impl Runtime<server::Bound> {
+    /// Returns the bound local address of the server
+    pub fn server_addr(&self) -> std::net::SocketAddr {
+        self.server.local_addr()
+    }
+
     /// Spawns the HTTPS server with the given `service`. A runtime handle without the bound server
     /// configuration is returned.
     ///
@@ -428,6 +433,11 @@ impl Runtime<server::Bound> {
 
 #[cfg(feature = "server")]
 impl Runtime<Option<server::Bound>> {
+    /// Returns the bound local address of the server
+    pub fn server_addr(&self) -> Option<std::net::SocketAddr> {
+        self.server.as_ref().map(|s| s.local_addr())
+    }
+
     /// Spawns the HTTPS server, if bound, with the given `service`. A runtime handle without the
     /// bound server configuration is returned.
     ///


### PR DESCRIPTION
It's not easy to know whether the server is listening, accepting
connections, etc.

This change adds some debug logging to the `server` and updates
`Runtime` to include `server_addr` accessors.