### PR TITLE
Add support for kubeconfig and impersonation flags

### DIFF
--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -32,7 +32,7 @@ pub struct ClientArgs {
 
     /// Group to impersonate for Kubernetes operations
     #[cfg_attr(feature = "clap", clap(long = "as-group"))]
-    pub impoersonate_group: Option<String>,
+    pub impersonate_group: Option<String>,
 }
 
 /// Indicates an error occurred while configuring the Kubernetes client

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -1,6 +1,6 @@
 //! Utilities for configuring a [`kube_client::Client`] from the command line
 
-use kube_client::config::{Kubeconfig, KubeConfigOptions};
+use kube_client::config::{KubeConfigOptions, Kubeconfig};
 pub use kube_client::*;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 /// Configures a Kubernetes client
-// TODO configure a --kubeconfig
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -72,15 +72,15 @@ impl ClientArgs {
             None => Kubeconfig::from_env()?.ok_or(config::KubeconfigError::FindPath)?,
         };
 
-        if let Some(impersonate) = self.impersonate {
+        if let Some(user) = self.impersonate {
             for auth in kubeconfig.auth_infos.iter_mut() {
-                auth.auth_info.impersonate = Some(impersonate.clone());
+                auth.auth_info.impersonate = Some(user.clone());
             }
         }
 
-        if let Some(impersonate_group) = self.impoersonate_group {
+        if let Some(group) = self.impersonate_group {
             for mut auth in kubeconfig.auth_infos.iter_mut() {
-                auth.auth_info.impersonate_groups = Some(vec![impersonate_group.clone()]);
+                auth.auth_info.impersonate_groups = Some(vec![group.clone()]);
             }
         }
 

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -1,6 +1,6 @@
 //! Utilities for configuring a [`kube_client::Client`] from the command line
 
-use kube_client::config::Kubeconfig;
+use kube_client::config::{Kubeconfig, KubeConfigOptions};
 pub use kube_client::*;
 use std::path::PathBuf;
 use thiserror::Error;


### PR DESCRIPTION
Adds support for the `--kubeconfig` flag to specify the path to a kubeconfig file to use.
Adds support for the `--as` and `--as-group` to support impersonation or a user or group.

Signed-off-by: Alex Leong <alex@buoyant.io>