### PR TITLE
Improve kubeconfig loading logic

### DIFF
--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -66,9 +66,13 @@ impl ClientArgs {
             user: self.user,
         };
 
+        // kubeconfig location tried in this order:
+        // -- kubeconfig flag
+        // KUBECONFIG env var
+        // $HOME/.kube/config
         let mut kubeconfig = match self.kubeconfig {
             Some(path) => config::Kubeconfig::read_from(path.as_path())?,
-            None => config::Kubeconfig::from_env()?.ok_or(config::KubeconfigError::FindPath)?,
+            None => config::Kubeconfig::read().map_err(|_| config::KubeconfigError::FindPath)?,
         };
 
         if let Some(user) = self.impersonate {

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -67,12 +67,12 @@ impl ClientArgs {
         };
 
         // kubeconfig location tried in this order:
-        // -- kubeconfig flag
-        // KUBECONFIG env var
-        // $HOME/.kube/config
+        // - --kubeconfig flag
+        // - $KUBECONFIG env var
+        // - $HOME/.kube/config
         let mut kubeconfig = match self.kubeconfig {
             Some(path) => config::Kubeconfig::read_from(path.as_path())?,
-            None => config::Kubeconfig::read().map_err(|_| config::KubeconfigError::FindPath)?,
+            None => config::Kubeconfig::read()?,
         };
 
         if let Some(user) = self.impersonate {


### PR DESCRIPTION
Followup to #21

Allow the kubeconfig loading logic to also consider `$HOME/.kube/config`