### PR TITLE
Add client integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+target

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
+      # Build the examples
       - name: Install rust
         run: |
           rm -rf $HOME/.cargo
@@ -31,26 +32,32 @@ jobs:
           source $HOME/.cargo/env
           echo "PATH=$PATH" >> $GITHUB_ENV
           cargo version
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - run: cargo build --package=kubert-examples --examples
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
       - run: k3d --version
       - run: k3d cluster create --no-lb --k3s-arg '--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*'
       - run: kubectl version
+      # Run the example locally
+      - name: Run watch-pods
+        run: |
+          cargo run --package=kubert-examples --example=watch-pods -- \
+              --exit \
+              --log-level=debug
       - name: Setup RBAC
         run: |
           kubectl create namespace kubert-test
           kubectl create serviceaccount --namespace=kubert-test watch-pods
           kubectl create clusterrole watch-pods --verb=get,list,watch --resource=pods
           kubectl create clusterrolebinding watch-pods --clusterrole=watch-pods --serviceaccount=kubert-test:watch-pods
-      # Run the example locally
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      - run: cargo build --package=kubert-examples --example=watch-pods
-      - name: Run cargo run watch-pods
+      - name: Run watch-pods with impersonation
         run: |
           cargo run --package=kubert-examples --example=watch-pods -- \
-              --as=system:serviceaccount:kubert-test:watch-pods \
               --exit \
-              --log-level=debug
+              --log-level=debug \
+              --as=system:serviceaccount:kubert-test:watch-pods \
+              --kubeconfig=$HOME/.kube/config
 
   in-cluster:
     timeout-minutes: 10

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,0 +1,74 @@
+name: client
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - '**/*.rs'
+      - .github/workflows/client.yml
+
+permissions:
+  contents: read
+
+env:
+  CARGO_ACTION_FMT_VERSION: v0.1.3
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  K3D_VERSION: v5.3.0
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  local:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      # Setup a cluster
+      - run: curl --proto =https --tlsv1.3 -fLsSv https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
+      - run: k3d --version
+      - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"
+      - run: kubectl version
+      # Run the example locally
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: cargo run un watch-pods
+        run: |
+          cargo run --package=kubert-examples  --example=watch-pods  -- \
+              --exit  --log-level=debug
+
+  in-cluster:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      # Setup a cluster
+      - run: curl --proto =https --tlsv1.3 -fLsSv https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
+      - run: k3d --version
+      - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"
+      - run: kubectl version
+      # Build a docker image with the examples
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+      - run: docker buildx build . -f examples/Dockerfile --tag kubert-examples:test --load
+      - run: k3d image import kubert-examples:test
+      # Run the example in-cluster
+      - name: Setup kubert-test RBAC
+        run: |
+          kubectl create namespace kubert-test
+          kubectl create serviceaccount --namespace=kubert-test watch-pods
+          kubectl create clusterrole watch-pods  --verb=get,list,watch --resource=pods
+          kubectl create clusterrolebinding watch-pods --clusterrole=watch-pods --serviceaccount=kubert-test:watch-pods
+      - name: kubectl run watch-pods
+        run: |
+          kubectl run watch-pods \
+              --attach \
+              --command \
+              --image=kubert-examples:test \
+              --image-pull-policy=Never \
+              --labels=olix0r.net/kubert-test=watch-pods \
+              --namespace=kubert-test \
+              --overrides='{"spec": {"serviceAccount": "watch-pods"}}' \
+              --quiet \
+              --restart=Never \
+              --rm \
+              -- \
+            watch-pods --exit --log-level=debug --selector=olix0r.net/kubert-test=watch-pods
+

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -22,6 +22,8 @@ jobs:
   local:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.56.1
     steps:
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -30,12 +30,20 @@ jobs:
       - run: k3d --version
       - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"
       - run: kubectl version
+      - name: Setup RBAC
+        run: |
+          kubectl create namespace kubert-test
+          kubectl create serviceaccount --namespace=kubert-test watch-pods
+          kubectl create clusterrole watch-pods --verb=get,list,watch --resource=pods
+          kubectl create clusterrolebinding watch-pods --clusterrole=watch-pods --serviceaccount=kubert-test:watch-pods
       # Run the example locally
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      - name: cargo run un watch-pods
+      - name: Run cargo run watch-pods
         run: |
-          cargo run --package=kubert-examples  --example=watch-pods  -- \
-              --exit  --log-level=debug
+          cargo run --package=kubert-examples --example=watch-pods -- \
+              --as=system:serviceaccount:kubert-test:watch-pods \
+              --exit \
+              --log-level=debug
 
   in-cluster:
     timeout-minutes: 10
@@ -46,19 +54,19 @@ jobs:
       - run: k3d --version
       - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"
       - run: kubectl version
+      - name: Setup RBAC
+        run: |
+          kubectl create namespace kubert-test
+          kubectl create serviceaccount --namespace=kubert-test watch-pods
+          kubectl create clusterrole watch-pods --verb=get,list,watch --resource=pods
+          kubectl create clusterrolebinding watch-pods --clusterrole=watch-pods --serviceaccount=kubert-test:watch-pods
       # Build a docker image with the examples
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
       - run: docker buildx build . -f examples/Dockerfile --tag kubert-examples:test --load
       - run: k3d image import kubert-examples:test
       # Run the example in-cluster
-      - name: Setup kubert-test RBAC
-        run: |
-          kubectl create namespace kubert-test
-          kubectl create serviceaccount --namespace=kubert-test watch-pods
-          kubectl create clusterrole watch-pods  --verb=get,list,watch --resource=pods
-          kubectl create clusterrolebinding watch-pods --clusterrole=watch-pods --serviceaccount=kubert-test:watch-pods
-      - name: kubectl run watch-pods
+      - name: Run kubectl run watch-pods
         run: |
           kubectl run watch-pods \
               --attach \

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -16,23 +16,24 @@ env:
   CARGO_NET_RETRY: 10
   K3D_VERSION: v5.3.0
   RUST_BACKTRACE: short
+  RUST_VERSION: 1.56.1
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
   local:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container:
-      image: docker://rust:1.56.1
     steps:
+      - name: Install rust
+        run: |
+          rm -rf $HOME/.cargo
+          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain=${RUST_VERSION}
+          source $HOME/.cargo/env
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          cargo version
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
       - run: k3d --version
-      - name: Install kubectl
-        run: |
-          version=$(curl --proto =https --tlsv1.3 -fLsSv https://dl.k8s.io/release/stable.txt)
-          curl --proto =https --tlsv1.3 -fLsSvo /usr/local/bin/kubectl "https://dl.k8s.io/release/$version/bin/linux/amd64/kubectl"
-          chmod 755 /usr/local/bin/kubectl
       - run: k3d cluster create --no-lb --k3s-arg '--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*'
       - run: kubectl version
       - name: Setup RBAC

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install rust
         run: |
           rm -rf $HOME/.cargo
-          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain=${RUST_VERSION}
+          curl --proto =https --tlsv1.3 -fLsSv https://sh.rustup.rs | sh -s -- -y --default-toolchain=${RUST_VERSION}
           source $HOME/.cargo/env
           echo "PATH=$PATH" >> $GITHUB_ENV
           cargo version

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -44,6 +44,7 @@ jobs:
           kubectl create clusterrolebinding watch-pods --clusterrole=watch-pods --serviceaccount=kubert-test:watch-pods
       # Run the example locally
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - run: cargo build --package=kubert-examples --example=watch-pods
       - name: Run cargo run watch-pods
         run: |
           cargo run --package=kubert-examples --example=watch-pods -- \

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -28,7 +28,12 @@ jobs:
       # Setup a cluster
       - run: curl --proto =https --tlsv1.3 -fLsSv https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
       - run: k3d --version
-      - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"
+      - name: Install kubectl
+        run: |
+          version=$(curl --proto =https --tlsv1.3 -fLsSv https://dl.k8s.io/release/stable.txt)
+          curl --proto =https --tlsv1.3 -fLsSvo /usr/local/bin/kubectl "https://dl.k8s.io/release/$version/bin/linux/amd64/kubectl"
+          chmod 755 /usr/local/bin/kubectl
+      - run: k3d cluster create --no-lb --k3s-arg '--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*'
       - run: kubectl version
       - name: Setup RBAC
         run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: docker://rust:1.58.1
+      image: docker://rust:1.56.1
     steps:
       - name: install cargo-action-fmt
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     container:
-      image: docker://rust:1.58.1
+      image: docker://rust:1.56.1
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - run: rustup component add rustfmt
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
-      image: docker://rust:1.58.1
+      image: docker://rust:1.56.1
     steps:
       - run: rustup component add clippy
       - name: install cargo-action-fmt
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
-      image: docker://rust:1.58.1-buster
+      image: docker://rust:1.56.1-buster
     steps:
       - run: |
           curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
-      image: docker://rust:1.58.1
+      image: docker://rust:1.56.1
     steps:
       - name: install cargo-action-fmt
         run: |

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,8 @@ skip = [
     { name = "parking_lot_core", version = "0.8" },
     # Waiting on h2, kube-client
     { name = "tokio-util", version = "0.6.9" },
+    # Waiting on getrandom
+    { name = "wasi", version = "0.10" },
 ]
 
 [sources]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = "1"
 clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
 futures = { version = "0.3", default-features = false }
 k8s-openapi = { version = "0.14", default-features = false, features = ["v1_23"] }
+regex = "1"
+thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies.kube]
@@ -37,7 +39,7 @@ features = [
 
 [dev-dependencies.tokio]
 version = "1"
-features = ["macros", "parking_lot", "rt", "rt-multi-thread"]
+features = ["macros", "parking_lot", "rt", "rt-multi-thread", "time"]
 
 [[example]]
 name = "watch-pods"

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -3,13 +3,8 @@ ARG RUST_VERSION=1.56.1
 FROM docker.io/library/rust:${RUST_VERSION}-bullseye as build
 WORKDIR /kubert
 COPY . .
-RUN --mount=type=cache,target=target \
-    --mount=type=cache,from=rust:1.56.1,source=/usr/local/cargo,target=/usr/local/cargo \
-    cargo fetch --locked
-RUN --mount=type=cache,target=target \
-    --mount=type=cache,from=rust:1.56.1,source=/usr/local/cargo,target=/usr/local/cargo \
-    cargo build --frozen --package kubert-examples --examples \
-        && mv target/debug/examples/watch-pods /tmp/watch-pods
+RUN cargo fetch --locked
+RUN cargo build --frozen --package=kubert-examples --examples
 
 FROM gcr.io/distroless/cc
-COPY --from=build /tmp/watch-pods /usr/local/bin/
+COPY --from=build /kubert/target/debug/examples/watch-pods /usr/local/bin/

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -3,7 +3,7 @@ ARG RUST_VERSION=1.56.1
 FROM docker.io/library/rust:${RUST_VERSION}-bullseye as build
 WORKDIR /kubert
 COPY . .
-RUN cargo fetch --locked
+RUN cargo fetch
 RUN cargo build --frozen --package=kubert-examples --examples
 
 FROM gcr.io/distroless/cc

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,15 @@
+ARG RUST_VERSION=1.56.1
+
+FROM docker.io/library/rust:${RUST_VERSION}-bullseye as build
+WORKDIR /kubert
+COPY . .
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.56.1,source=/usr/local/cargo,target=/usr/local/cargo \
+    cargo fetch --locked
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.56.1,source=/usr/local/cargo,target=/usr/local/cargo \
+    cargo build --frozen --package kubert-examples --examples \
+        && mv target/debug/examples/watch-pods /tmp/watch-pods
+
+FROM gcr.io/distroless/cc
+COPY --from=build /tmp/watch-pods /usr/local/bin/

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -6,11 +6,13 @@ use clap::Parser;
 use futures::prelude::*;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{api::ListParams, runtime::watcher::Event, ResourceExt};
+use tokio::time;
 use tracing::Instrument;
 
 #[derive(Parser)]
 #[clap(version)]
 struct Args {
+    /// The tracing filter used for logs
     #[clap(
         long,
         env = "KUBERT_EXAMPLE_LOG",
@@ -18,6 +20,7 @@ struct Args {
     )]
     log_level: kubert::LogFilter,
 
+    /// The logging format
     #[clap(long, default_value = "plain")]
     log_format: kubert::LogFormat,
 
@@ -27,6 +30,15 @@ struct Args {
     #[clap(flatten)]
     admin: kubert::AdminArgs,
 
+    /// Exit after the first update is received
+    #[clap(long)]
+    exit: bool,
+
+    /// The amount of time to wait for the first update
+    #[clap(long, default_value = "10s")]
+    timeout: Timeout,
+
+    /// An optional pod selector
     #[clap(long, short = 'l')]
     selector: Option<String>,
 }
@@ -38,19 +50,25 @@ async fn main() -> Result<()> {
         log_format,
         client,
         admin,
+        exit,
+        timeout: Timeout(timeout),
         selector,
     } = Args::parse();
+
+    let deadline = time::Instant::now() + timeout;
 
     // Configure a runtime with:
     // - a Kubernetes client
     // - an admin server with /live and /ready endpoints
     // - a tracing (logging) subscriber
-    let mut runtime = kubert::Runtime::builder()
+    let rt = kubert::Runtime::builder()
         .with_log(log_level, log_format)
         .with_admin(admin)
-        .with_client(client)
-        .build()
-        .await?;
+        .with_client(client);
+    let mut runtime = match time::timeout_at(deadline, rt.build()).await {
+        Ok(res) => res?,
+        Err(_) => bail!("Timed out waiting for Kubernetes client to initialize"),
+    };
 
     // Watch all pods and print changes.
     //
@@ -59,16 +77,17 @@ async fn main() -> Result<()> {
     tracing::debug!(?selector);
     let params = selector
         .iter()
-        .fold(ListParams::default(), |p, l| p.labels(&l));
+        .fold(ListParams::default(), |p, l| p.labels(l));
     let pods = runtime.watch_all::<Pod>(params);
-    tokio::spawn(
+    let mut deadline = Some(deadline);
+    let task = tokio::spawn(
         async move {
             tokio::pin!(pods);
 
             // Keep a list of all known pods so we can identify new and deleted pods on restart.
             // The watch will restart roughly every 5 minutes.
             let mut known = std::collections::HashSet::<(String, String)>::new();
-            while let Some(ev) = pods.next().await {
+            while let Some(ev) = init_timeout(deadline.take(), pods.next()).await? {
                 tracing::trace!(?ev);
                 match ev {
                     Event::Restarted(pods) => {
@@ -110,18 +129,69 @@ async fn main() -> Result<()> {
                         known.remove(&(namespace, name));
                     }
                 }
+
+                if exit {
+                    return Ok::<_, anyhow::Error>(());
+                }
             }
             tracing::debug!("completed");
+            Ok(())
         }
         .instrument(tracing::info_span!("pods")),
     );
 
-    // Block the main thread on the shutdown signal. This won't complete until the watch stream
-    // stops (after pending Pod updates are logged). If a second signal is received before the watch
-    // stream completes, the future fails.
-    if runtime.run().await.is_err() {
-        bail!("aborted");
+    tokio::select! {
+        // Block the main thread on the shutdown signal. This won't complete until the watch stream
+        // stops (after pending Pod updates are logged). If a second signal is received before the watch
+        // stream completes, the future fails.
+        res = runtime.run() => {
+            if res.is_err() {
+                bail!("aborted");
+            }
+        }
+
+        // If the watch stream completes, exit gracefully
+        res = task => match res {
+            Err(error) => bail!("spawned task failed: {}", error),
+            Ok(Err(_)) => bail!("Timed out waiting for the first update"),
+            Ok(Ok(())) => {
+                tracing::debug!("watch completed");
+            }
+        },
     }
 
     Ok(())
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Timeout(time::Duration);
+
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+#[error("invalid duration")]
+struct InvalidTimeout;
+
+impl std::str::FromStr for Timeout {
+    type Err = InvalidTimeout;
+
+    fn from_str(s: &str) -> Result<Self, InvalidTimeout> {
+        let re = regex::Regex::new(r"^\s*(\d+)(ms|s|m)?\s*$").expect("duration regex");
+        let cap = re.captures(s).ok_or(InvalidTimeout)?;
+        let magnitude = cap[1].parse().map_err(|_| InvalidTimeout)?;
+        let t = match cap.get(2).map(|m| m.as_str()) {
+            None if magnitude == 0 => time::Duration::from_millis(0),
+            Some("ms") => time::Duration::from_millis(magnitude),
+            Some("s") => time::Duration::from_secs(magnitude),
+            Some("m") => time::Duration::from_secs(magnitude * 60),
+            _ => return Err(InvalidTimeout),
+        };
+        Ok(Self(t))
+    }
+}
+
+async fn init_timeout<F: Future>(deadline: Option<time::Instant>, future: F) -> Result<F::Output> {
+    if let Some(deadline) = deadline {
+        return time::timeout_at(deadline, future).await.map_err(Into::into);
+    }
+
+    Ok(future.await)
 }


### PR DESCRIPTION
The client initialization logic isn't tested in this repo.

This change adds a `client` CI workflow that tests that the `watch-pods`
example runs both from within the cluster and from an external client.

It also pins all rust versions to the MSRV (1.56.1).