### PR TITLE
Add an `index` utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Rust Kubernetes runtime helpers. Based on [`kube-rs`][krs].
 
 ## Features
 
-* [`clap`](https://docs.rs/clap) command-line interface support
+* [`clap`](https://docs.rs/clap) command-line interface support;
 * A basic admin server with `/ready` and `/live` probe endpoints;
-* A default Kubernetes client
-* Graceful shutdown on `SIGTERM` or `SIGINT` signals
-* An HTTPS server (for admission controllers and API extensions) with certificate reloading
-* A _requeue_ channel that supports deferring/rescheduling updates (i.e. in case a write fails).
-* A [`Runtime`][rt] type that ties it all together!
+* A default Kubernetes client;
+* Graceful shutdown on `SIGTERM` or `SIGINT` signals;
+* An HTTPS server (for admission controllers and API extensions) with certificate reloading;
+* A utility for maintaining an index derived from watching one or more Kubernetes resources types;
+* A _requeue_ channel that supports deferring/rescheduling updates (i.e. in case a write fails);
+* And a [`Runtime`][rt] type that ties it all together!
 
 ### Why not `kube-rs`?
 

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -13,6 +13,15 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 admin = ["futures-util", "hyper/http1", "hyper/runtime", "hyper/server", "tokio/sync", "tracing"]
 client = ["kube-client", "thiserror"]
 errors = ["futures-core", "futures-util", "pin-project-lite", "tokio/time", "tracing"]
+index = [
+    "ahash",
+    "futures-core",
+    "futures-util",
+    "kube-core",
+    "kube-runtime",
+    "parking_lot",
+    "tracing",
+]
 initialized = ["futures-core", "futures-util", "pin-project-lite", "tokio/sync"]
 log = ["thiserror", "tracing", "tracing-subscriber"]
 requeue = ["futures-core", "tokio/macros", "tokio/sync", "tokio-util/time", "tracing"]
@@ -70,10 +79,12 @@ features = [
 ]
 
 [dependencies]
+ahash = { version = "0.7", optional = true }
 drain = { version = "0.1.1", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
+parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 rustls-pemfile = { version = "0.3.0", optional = true }
 thiserror = { version = "1.0.30", optional = true }

--- a/kubert/src/index.rs
+++ b/kubert/src/index.rs
@@ -1,0 +1,138 @@
+//! Utilities for maintaining a shared index derived from Kubernetes resources.
+
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
+use futures_util::StreamExt;
+use kube_core::{Resource, ResourceExt};
+use kube_runtime::watcher::Event;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+/// Processes updates to `T`-typed cluster-scoped Kubernetes resources.
+pub trait IndexClusterResource<T> {
+    /// Processes an update to a Kubernetes resource.
+    fn apply(&mut self, resource: T);
+
+    /// Observes the removal of a Kubernetes resource.
+    fn delete(&mut self, name: String);
+
+    /// Snapshots the names of all `T`-typed resources in the index.
+    fn snapshot_keys(&self) -> HashSet<String>;
+}
+
+/// Processes updates to `T`-typed namespaced Kubernetes resources.
+pub trait IndexNamespacedResource<T> {
+    /// Processes an update to a Kubernetes resource.
+    fn apply(&mut self, resource: T);
+
+    /// Observes the removal of a Kubernetes resource.
+    fn delete(&mut self, namespace: String, name: String);
+
+    /// Snapshots the names of all `T`-typed resources in the index.
+    ///
+    /// Returns a map of namespaces to sets of names of resources in that namespace.
+    fn snapshot_keys(&self) -> HashMap<String, HashSet<String>>;
+}
+
+/// Updates a `T`-typed index from a watch on a `R`-typed namespaced Kubernetes resource.
+pub async fn namespaced<T, R>(
+    index: Arc<RwLock<T>>,
+    events: impl futures_core::Stream<Item = Event<R>>,
+) where
+    T: IndexNamespacedResource<R>,
+    R: Resource + std::fmt::Debug,
+{
+    tokio::pin!(events);
+
+    while let Some(event) = events.next().await {
+        tracing::trace!(?event);
+        match event {
+            Event::Applied(resource) => {
+                index.write().apply(resource);
+            }
+
+            Event::Deleted(resource) => {
+                let namespace = resource
+                    .namespace()
+                    .expect("resource must have a namespace");
+                index.write().delete(namespace, resource.name());
+            }
+
+            Event::Restarted(resources) => {
+                let mut idx = index.write();
+
+                // Iterate through all the resources in the restarted event and add/update them in the
+                // index, keeping track of which resources need to be removed from the index.
+                let mut snapshot = idx.snapshot_keys();
+                for resource in resources.into_iter() {
+                    let namespace = resource
+                        .namespace()
+                        .expect("resource must have a namespace");
+                    let name = resource.name();
+
+                    // If the resource was in the index and is being updated, it doesn't need to be
+                    // removed.
+                    if let Some(snapshot) = snapshot.get_mut(&namespace) {
+                        snapshot.remove(&name);
+                    }
+
+                    idx.apply(resource);
+                }
+
+                // Remove all resources that were in the index but are no longer in the cluster
+                // following a restart.
+                for (ns, resources) in snapshot.into_iter() {
+                    for name in resources.into_iter() {
+                        idx.delete(ns.clone(), name);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Updates a `T`-typed index from a watch on a `R`-typed cluster-scoped Kubernetes resource.
+pub async fn cluster<T, R>(
+    index: Arc<RwLock<T>>,
+    events: impl futures_core::Stream<Item = Event<R>>,
+) where
+    T: IndexClusterResource<R>,
+    R: Resource + std::fmt::Debug,
+{
+    tokio::pin!(events);
+
+    while let Some(event) = events.next().await {
+        tracing::trace!(?event);
+        match event {
+            Event::Applied(resource) => {
+                index.write().apply(resource);
+            }
+
+            Event::Deleted(resource) => {
+                index.write().delete(resource.name());
+            }
+
+            Event::Restarted(resources) => {
+                let mut idx = index.write();
+
+                // Iterate through all the resources in the restarted event and add/update them in the
+                // index, keeping track of which resources need to be removed from the index.
+                let mut snapshot = idx.snapshot_keys();
+                for resource in resources.into_iter() {
+                    let name = resource.name();
+
+                    // If the resource was in the index and is being updated, it doesn't need to be
+                    // removed.
+                    snapshot.remove(&name);
+
+                    idx.apply(resource);
+                }
+
+                // Remove all resources that were in the index but are no longer in the cluster
+                // following a restart.
+                for name in snapshot.into_iter() {
+                    idx.delete(name);
+                }
+            }
+        }
+    }
+}

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -18,6 +18,10 @@ pub mod client;
 #[cfg_attr(docsrs, doc(cfg(feature = "errors")))]
 pub mod errors;
 
+#[cfg(feature = "index")]
+#[cfg_attr(docsrs, doc(cfg(feature = "index")))]
+pub mod index;
+
 #[cfg(feature = "initialized")]
 #[cfg_attr(docsrs, doc(cfg(feature = "initialized")))]
 pub mod initialized;


### PR DESCRIPTION
When watching Kubernetes resources and keeping a data structure up-to
date, there's a fairly straightforward pattern for keeping a
data-structure up-to-date.

This change adds a `index` module that drive the main event-looping
logic, locking a data structure, and applying updates, ensuring that the
data structure observes implicit removing following a stream restart.