### PR TITLE
Change `index` to keep track of its keys

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,7 @@ license-files = [
 
 [bans]
 multiple-versions = "deny"
-wildcards = "deny"
+wildcards = "allow"
 highlight = "all"
 deny = []
 skip-tree = []

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,7 +30,6 @@ features = [
 
 [dev-dependencies.kubert]
 path = "../kubert"
-version = "0.3.0"
 default-features = false
 features = [
     "clap",

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."

--- a/kubert/src/index.rs
+++ b/kubert/src/index.rs
@@ -5,7 +5,7 @@ use futures_util::StreamExt;
 use kube_core::{Resource, ResourceExt};
 use kube_runtime::watcher::Event;
 use parking_lot::RwLock;
-use std::sync::Arc;
+use std::{collections::hash_map::Entry, sync::Arc};
 
 /// Processes updates to `T`-typed cluster-scoped Kubernetes resources.
 pub trait IndexClusterResource<T> {
@@ -14,9 +14,6 @@ pub trait IndexClusterResource<T> {
 
     /// Observes the removal of a Kubernetes resource.
     fn delete(&mut self, name: String);
-
-    /// Snapshots the names of all `T`-typed resources in the index.
-    fn snapshot_keys(&self) -> HashSet<String>;
 }
 
 /// Processes updates to `T`-typed namespaced Kubernetes resources.
@@ -26,11 +23,6 @@ pub trait IndexNamespacedResource<T> {
 
     /// Observes the removal of a Kubernetes resource.
     fn delete(&mut self, namespace: String, name: String);
-
-    /// Snapshots the names of all `T`-typed resources in the index.
-    ///
-    /// Returns a map of namespaces to sets of names of resources in that namespace.
-    fn snapshot_keys(&self) -> HashMap<String, HashSet<String>>;
 }
 
 /// Updates a `T`-typed index from a watch on a `R`-typed namespaced Kubernetes resource.
@@ -43,10 +35,18 @@ pub async fn namespaced<T, R>(
 {
     tokio::pin!(events);
 
+    let mut keys = HashMap::new();
     while let Some(event) = events.next().await {
         tracing::trace!(?event);
         match event {
             Event::Applied(resource) => {
+                let namespace = resource
+                    .namespace()
+                    .expect("resource must have a namespace");
+                let name = resource.name();
+                keys.entry(namespace)
+                    .or_insert_with(HashSet::new)
+                    .insert(name);
                 index.write().apply(resource);
             }
 
@@ -54,35 +54,47 @@ pub async fn namespaced<T, R>(
                 let namespace = resource
                     .namespace()
                     .expect("resource must have a namespace");
-                index.write().delete(namespace, resource.name());
+                let name = resource.name();
+                if let Entry::Occupied(mut entry) = keys.entry(namespace.clone()) {
+                    entry.get_mut().remove(&name);
+                    if entry.get().is_empty() {
+                        entry.remove();
+                    }
+                }
+                index.write().delete(namespace, name);
             }
 
             Event::Restarted(resources) => {
                 let mut idx = index.write();
 
-                // Iterate through all the resources in the restarted event and add/update them in the
-                // index, keeping track of which resources need to be removed from the index.
-                let mut snapshot = idx.snapshot_keys();
+                // Iterate through all the resources in the restarted event and add/update them in
+                // the index, keeping track of which resources need to be removed from the index.
+                let mut prior_keys = keys.clone();
                 for resource in resources.into_iter() {
                     let namespace = resource
                         .namespace()
                         .expect("resource must have a namespace");
                     let name = resource.name();
-
-                    // If the resource was in the index and is being updated, it doesn't need to be
-                    // removed.
-                    if let Some(snapshot) = snapshot.get_mut(&namespace) {
-                        snapshot.remove(&name);
+                    if let Some(pk) = prior_keys.get_mut(&namespace) {
+                        pk.remove(&name);
                     }
-
+                    keys.entry(namespace)
+                        .or_insert_with(HashSet::new)
+                        .insert(name);
                     idx.apply(resource);
                 }
 
                 // Remove all resources that were in the index but are no longer in the cluster
                 // following a restart.
-                for (ns, resources) in snapshot.into_iter() {
+                for (namespace, resources) in prior_keys.into_iter() {
                     for name in resources.into_iter() {
-                        idx.delete(ns.clone(), name);
+                        if let Entry::Occupied(mut entry) = keys.entry(namespace.clone()) {
+                            entry.get_mut().remove(&name);
+                            if entry.get().is_empty() {
+                                entry.remove();
+                            }
+                        }
+                        idx.delete(namespace.clone(), name);
                     }
                 }
             }
@@ -100,37 +112,193 @@ pub async fn cluster<T, R>(
 {
     tokio::pin!(events);
 
+    let mut keys = HashSet::new();
     while let Some(event) = events.next().await {
         tracing::trace!(?event);
         match event {
             Event::Applied(resource) => {
+                keys.insert(resource.name());
                 index.write().apply(resource);
             }
 
             Event::Deleted(resource) => {
-                index.write().delete(resource.name());
+                let name = resource.name();
+                keys.remove(&name);
+                index.write().delete(name);
             }
 
             Event::Restarted(resources) => {
                 let mut idx = index.write();
 
-                // Iterate through all the resources in the restarted event and add/update them in the
-                // index, keeping track of which resources need to be removed from the index.
-                let mut snapshot = idx.snapshot_keys();
+                // Iterate through all the resources in the restarted event and add/update them in
+                // the index, keeping track of which resources need to be removed from the index.
+                let mut prior_keys = keys.clone();
                 for resource in resources.into_iter() {
                     let name = resource.name();
-
-                    // If the resource was in the index and is being updated, it doesn't need to be
-                    // removed.
-                    snapshot.remove(&name);
-
+                    prior_keys.remove(&name);
+                    keys.insert(name);
                     idx.apply(resource);
                 }
 
                 // Remove all resources that were in the index but are no longer in the cluster
                 // following a restart.
-                for name in snapshot.into_iter() {
+                for name in prior_keys.into_iter() {
+                    keys.remove(&name);
                     idx.delete(name);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+    use tokio_test::{assert_pending, task};
+
+    #[test]
+    fn namespaced_restart() {
+        let state = Arc::new(RwLock::new(NsCache(HashMap::new())));
+        let (tx, rx) = mpsc::channel(1);
+        let mut task = task::spawn(namespaced(state.clone(), ReceiverStream::new(rx)));
+
+        tx.try_send(kube::runtime::watcher::Event::Restarted(
+            (0..2)
+                .map(|i| k8s_openapi::api::core::v1::Pod {
+                    metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                        namespace: Some("default".to_string()),
+                        name: Some(format!("pod-{}", i)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .collect(),
+        ))
+        .unwrap();
+        assert_pending!(task.poll());
+        assert_eq!(
+            state.read().0,
+            Some((
+                "default".to_string(),
+                vec!["pod-0".to_string(), "pod-1".to_string(),]
+                    .into_iter()
+                    .collect()
+            ))
+            .into_iter()
+            .collect()
+        );
+
+        tx.try_send(kube::runtime::watcher::Event::Restarted(
+            (1..3)
+                .map(|i| k8s_openapi::api::core::v1::Pod {
+                    metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                        namespace: Some("default".to_string()),
+                        name: Some(format!("pod-{}", i)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .collect(),
+        ))
+        .unwrap();
+        assert_pending!(task.poll());
+        assert_eq!(
+            state.read().0,
+            Some((
+                "default".to_string(),
+                vec!["pod-1".to_string(), "pod-2".to_string(),]
+                    .into_iter()
+                    .collect()
+            ))
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn clustered_restart() {
+        let state = Arc::new(RwLock::new(ClusterCache(HashSet::new())));
+        let (tx, rx) = mpsc::channel(1);
+        let mut task = task::spawn(cluster(state.clone(), ReceiverStream::new(rx)));
+
+        tx.try_send(kube::runtime::watcher::Event::Restarted(
+            (0..2)
+                .map(|i| k8s_openapi::api::core::v1::Namespace {
+                    metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                        namespace: Some("default".to_string()),
+                        name: Some(format!("ns-{}", i)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .collect(),
+        ))
+        .unwrap();
+        assert_pending!(task.poll());
+        assert_eq!(
+            state.read().0,
+            vec!["ns-0".to_string(), "ns-1".to_string()]
+                .into_iter()
+                .collect()
+        );
+
+        tx.try_send(kube::runtime::watcher::Event::Restarted(
+            (1..3)
+                .map(|i| k8s_openapi::api::core::v1::Namespace {
+                    metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                        namespace: Some("default".to_string()),
+                        name: Some(format!("ns-{}", i)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .collect(),
+        ))
+        .unwrap();
+        assert_pending!(task.poll());
+        assert_eq!(
+            state.read().0,
+            vec!["ns-1".to_string(), "ns-2".to_string()]
+                .into_iter()
+                .collect(),
+        );
+    }
+
+    struct ClusterCache(HashSet<String>);
+
+    struct NsCache(HashMap<String, HashSet<String>>);
+
+    impl<T: Resource> IndexClusterResource<T> for ClusterCache {
+        fn apply(&mut self, resource: T) {
+            self.0.insert(resource.name());
+        }
+
+        fn delete(&mut self, name: String) {
+            self.0.remove(&*name);
+        }
+    }
+
+    impl<T: Resource> IndexNamespacedResource<T> for NsCache {
+        fn apply(&mut self, resource: T) {
+            let namespace = resource
+                .namespace()
+                .expect("resource must have a namespace");
+            let name = resource.name();
+            self.0
+                .entry(namespace)
+                .or_insert_with(HashSet::new)
+                .insert(name);
+        }
+
+        fn delete(&mut self, namespace: String, name: String) {
+            if let Entry::Occupied(mut entry) = self.0.entry(namespace) {
+                entry.get_mut().remove(&name);
+                if entry.get().is_empty() {
+                    entry.remove();
                 }
             }
         }


### PR DESCRIPTION
Rather than force the indexing type to keep track of its own key
structures, it's better for the indexer to do this internaly. This makes
it so that the hash implementation isn't a part of the public interface;
and also makes it so that the index implementation need not track all
resources for proper operations.

This is a breaing change that removes the `snapshot_keys` method from
the `IndexClusterResource` and `IndexNamespacedResource` traits. As
such, the crate version is bumped to v0.4.0