### PR TITLE
index: Allow indexers to handle restarts

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."


### PR DESCRIPTION
Indexers may want to handle batch updates specially, for instance to
run an expensive computation after the batch update is applied. With the
current `Index` trait APIs, this is not possible.

This change adds `IndexClusterResources::reset` and
`IndexNamespacedResources::reset` methods with a default implementation
that preserves the current behavior: `apply` is called for each live
resource and `delete` is called for all resources that aren't included
in the update. This default trait-method implementation ensures this
change is backwards-compatible.