### PR TITLE
ci: Parallelize per-feature checks

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -18,21 +18,39 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  features:
-    timeout-minutes: 15
+  feature-list:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     container:
       image: docker://rust:1.56.1
     steps:
-      - name: install cargo-action-fmt
+      - name: Install tools
+        run: |
+          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          chmod 755 /usr/local/bin/jq
+      - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
+      - run: cargo fetch
+      - id: list-features
+        run: |
+          features=$(cargo metadata --format-version=1 | jq -c '.packages[] | select(.name == "kubert") | .features | keys')
+          echo "::set-output name=features::$features"
+    outputs:
+      features: ${{ steps.list-features.outputs.features }}
+
+  feature-check:
+    needs: [feature-list]
+    strategy:
+      matrix:
+        feature: ${{ fromJson(needs.feature-list.outputs.features) }}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.56.1
+    steps:
+      - name: Install tools
         run: |
           curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
           chmod 755 /usr/local/bin/cargo-action-fmt
-      - name: install cargo-hack
-        run: |
-          curl --proto =https --tlsv1.3 -vsSfL https://github.com/taiki-e/cargo-hack/releases/download/v0.5.12/cargo-hack-x86_64-unknown-linux-gnu.tar.gz \
-            | tar -xz -C /usr/local/bin/ \
-            && chmod 755 /usr/local/bin/cargo-hack
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
       - run: cargo fetch
-      - run: cargo hack --feature-powerset --workspace check --all-targets --message-format=json | cargo-action-fmt
+      - run: cargo check --features=${{ matrix.feature }} --all-targets --message-format=json | cargo-action-fmt


### PR DESCRIPTION
This replaces use of `cargo-hack` with a build matrix that compiles each
feature independently.

Signed-off-by: Oliver Gould <ver@buoyant.io>