### PR TITLE
log: add tokio-console support

### DIFF
--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -12,17 +12,8 @@ use tracing::Instrument;
 #[derive(Parser)]
 #[clap(version)]
 struct Args {
-    /// The tracing filter used for logs
-    #[clap(
-        long,
-        env = "KUBERT_EXAMPLE_LOG",
-        default_value = "watch_pods=info,warn"
-    )]
-    log_level: kubert::LogFilter,
-
-    /// The logging format
-    #[clap(long, default_value = "plain")]
-    log_format: kubert::LogFormat,
+    #[clap(flatten)]
+    log: kubert::LogArgs,
 
     #[clap(flatten)]
     client: kubert::ClientArgs,
@@ -46,8 +37,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let Args {
-        log_level,
-        log_format,
+        log,
         client,
         admin,
         exit,
@@ -62,7 +52,7 @@ async fn main() -> Result<()> {
     // - an admin server with /live and /ready endpoints
     // - a tracing (logging) subscriber
     let rt = kubert::Runtime::builder()
-        .with_log(log_level, log_format)
+        .with_log(log.log_level(), log.log_format)
         .with_admin(admin)
         .with_client(client);
     let mut runtime = match time::timeout_at(deadline, rt.build()).await {

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
     // - an admin server with /live and /ready endpoints
     // - a tracing (logging) subscriber
     let rt = kubert::Runtime::builder()
-        .with_log(log.log_level(), log.log_format)
+        .with_log_args(log)
         .with_admin(admin)
         .with_client(client);
     let mut runtime = match time::timeout_at(deadline, rt.build()).await {

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -24,6 +24,7 @@ index = [
 ]
 initialized = ["futures-core", "futures-util", "pin-project-lite", "tokio/sync"]
 log = ["thiserror", "tracing", "tracing-subscriber", "once_cell"]
+tokio-console = ["tracing-subscriber", "console-subscriber"]
 requeue = ["futures-core", "tokio/macros", "tokio/sync", "tokio-util/time", "tracing"]
 runtime = [
     "admin",
@@ -80,6 +81,7 @@ features = [
 
 [dependencies]
 ahash = { version = "0.7", optional = true }
+console-subscriber = { version = "0.1", optional = true }
 drain = { version = "0.1.1", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
@@ -126,7 +128,7 @@ optional = true
 default-features = false
 
 [dependencies.tracing-subscriber]
-version = "0.3.9"
+version = "0.3.11"
 optional = true
 default-features = false
 features = [

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -23,7 +23,7 @@ index = [
     "tracing",
 ]
 initialized = ["futures-core", "futures-util", "pin-project-lite", "tokio/sync"]
-log = ["thiserror", "tracing", "tracing-subscriber"]
+log = ["thiserror", "tracing", "tracing-subscriber", "once_cell"]
 requeue = ["futures-core", "tokio/macros", "tokio/sync", "tokio-util/time", "tracing"]
 runtime = [
     "admin",
@@ -94,6 +94,7 @@ tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.23.2", optional = true, default-features = false }
 tower-service = { version = "0.3.1", optional = true }
 tracing = { version = "0.1.31", optional = true }
+once_cell = { version = "1.10", optional = true }
 
 [dependencies.clap]
 version = "3.1.0"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -102,7 +102,7 @@ once_cell = { version = "1.10", optional = true }
 version = "3.1.0"
 optional = true
 default-features = false
-features = ["derive", "std"]
+features = ["derive", "std", "env"]
 
 # Not used directly, but required to ensure that the k8s-openapi dependency is considered part of
 # the "deps" graph rather than just the "dev-deps" graph
@@ -149,4 +149,4 @@ tracing-subscriber = { version = "0.3", features = ["ansi"] }
 [dev-dependencies.tokio]
 version = "1.17"
 default-features = false
-features = ["macros", "test-util"]
+features = ["macros", "test-util", "rt-multi-thread"]

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -58,6 +58,13 @@ pub struct Server {
     task: tokio::task::JoinHandle<Result<()>>,
 }
 
+#[derive(Debug)]
+#[cfg(feature = "tokio-console")]
+struct Console {
+    server: console_subscriber::Server,
+    grpc: tonic::server::Grpc<tonic::codec::ProstCodec>,
+}
+
 // === impl AdminArgs ===
 
 impl Default for AdminArgs {
@@ -150,7 +157,8 @@ impl Bound {
                 ))
             }));
 
-        let task = tokio::spawn(
+        let task = crate::spawn_named(
+            "kubert::admin",
             async move {
                 debug!("Serving");
                 server.await

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -58,13 +58,6 @@ pub struct Server {
     task: tokio::task::JoinHandle<Result<()>>,
 }
 
-#[derive(Debug)]
-#[cfg(feature = "tokio-console")]
-struct Console {
-    server: console_subscriber::Server,
-    grpc: tonic::server::Grpc<tonic::codec::ProstCodec>,
-}
-
 // === impl AdminArgs ===
 
 impl Default for AdminArgs {

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -63,3 +63,19 @@ pub use self::runtime::Runtime;
 
 #[cfg(all(feature = "server"))]
 pub use self::server::ServerArgs;
+
+#[cfg(all(tokio_unstable, feature = "tokio-console"))]
+pub(crate) fn spawn_named<T>(
+    name: &'static str,
+    f: impl std::future::Future<Output = T> + Send,
+) -> tokio::task::JoinHandle<T> {
+    tokio::task::Builder::new().name(name).spawn(f)
+}
+
+#[cfg(not(all(tokio_unstable, feature = "tokio-console")))]
+pub(crate) fn spawn_named<T>(
+    _: &'static str,
+    f: impl std::future::Future<Output = T> + Send,
+) -> tokio::task::JoinHandle<T> {
+    tokio::spawn(f)
+}

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::client::ClientArgs;
 pub use self::initialized::Initialized;
 
 #[cfg(all(feature = "log"))]
-pub use self::log::{LogFilter, LogFormat, LogInitError};
+pub use self::log::{LogArgs, LogFilter, LogFormat, LogInitError};
 
 #[cfg(all(feature = "runtime"))]
 pub use self::runtime::Runtime;

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -65,17 +65,25 @@ pub use self::runtime::Runtime;
 pub use self::server::ServerArgs;
 
 #[cfg(all(tokio_unstable, feature = "tokio-console"))]
+#[track_caller]
 pub(crate) fn spawn_named<T>(
     name: &'static str,
-    f: impl std::future::Future<Output = T> + Send,
-) -> tokio::task::JoinHandle<T> {
+    f: impl std::future::Future<Output = T> + Send + 'static,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+{
     tokio::task::Builder::new().name(name).spawn(f)
 }
 
 #[cfg(not(all(tokio_unstable, feature = "tokio-console")))]
+#[track_caller]
 pub(crate) fn spawn_named<T>(
     _: &'static str,
-    f: impl std::future::Future<Output = T> + Send,
-) -> tokio::task::JoinHandle<T> {
+    f: impl std::future::Future<Output = T> + Send + 'static,
+) -> tokio::task::JoinHandle<T>
+where
+    T: Send + 'static,
+{
     tokio::spawn(f)
 }

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -70,11 +70,9 @@ use once_cell::sync::OnceCell;
 ///
 ///      // Construct a `LogArgs` from the values we parsed using our
 ///      // custom configuration:
-///     let log_args = kubert::LogArgs {
-///         log_level: args.log_filter,
-///         log_format: args.log_format,
-///         ..Default::default()
-///     };
+///     let log_args = kubert::LogArgs::default()
+///         .with_log_format(args.log_format)
+///         .with_log_level(args.log_filter);
 ///
 ///     let rt = kubert::Runtime::builder()
 ///         .with_log_args(log_args)
@@ -166,6 +164,14 @@ impl LogFormat {
 // === impl LogArgs ===
 
 impl LogArgs {
+    pub fn with_log_format(self, log_format: LogFormat) -> Self {
+        Self { log_format, ..self }
+    }
+
+    pub fn with_log_level(self, log_level: LogFilter) -> Self {
+        Self { log_level, ..self }
+    }
+
     /// Attempts to configure the global default `tracing` subscriber in the current scope, returning
     /// an error if one is already set
     ///

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -8,36 +8,25 @@ pub use tracing_subscriber::{util::TryInitError as LogInitError, EnvFilter as Lo
 use clap::{Arg, ArgEnum, ArgMatches, Args, Command, FromArgMatches};
 
 /// Configures logging settings.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
 pub struct LogArgs {
     /// The log format to use.
-    #[cfg_attr(
-        feature = "clap",
-        clap(long, default_value = "plain", possible_values = ["plain", "json"])
-    )]
     pub log_format: LogFormat,
 
     /// The filter that determines what tracing spans and events are enabled.
-    #[cfg_attr(feature = "clap", clap(flatten))]
     pub log_level: LogFilter,
 
     /// Enables tokio-console support.
     ///
     /// If this is set, `kubert` must be compiled with the `tokio-console` cargo
     /// feature enabled and `RUSTFLAGS="--cfg tokio_unstable"` must be set.
-    #[cfg(all(tokio_unstable, feature = "tokio-console"))]
-    #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tokio-console"))))]
-    #[cfg_attr(feature = "clap", clap(long, parse = validate_console))]
+    #[cfg(feature = "tokio-console")]
     pub tokio_console: bool,
+
+    pub(crate) _p: (),
 }
 
-impl LogArgs {
-    /// Returns the log level filter.
-    pub fn log_level(&self) -> LogFilter {
-        self.log_level.0.clone()
-    }
-}
 /// Configures whether logs should be emitted in plaintext (the default) or as JSON-encoded
 /// messages
 #[derive(Clone, Debug)]
@@ -78,18 +67,46 @@ impl std::str::FromStr for LogFormat {
 }
 
 impl LogFormat {
-    /// Attempts to configure the global default tracing subscriber in the current scope, returning
+    /// Attempts to configure the global default `tracing` subscriber in the current scope, returning
     /// an error if one is already set
     ///
-    /// This method returns an error if a global default subscriber has already been set, or if a
+    /// This method returns an error if [a global default subscriber has already been set][set], or if a
     /// `log` logger has already been set.
+    ///
+    /// [set]: https://docs.rs/tracing-subscriber
+    #[deprecated(since = "0.6.1", note = "use `LogArgs::try_init` instead")]
     pub fn try_init(self, filter: LogFilter) -> Result<(), LogInitError> {
+        LogArgs {
+            log_format: self,
+            log_level: filter,
+            tokio_console: false,
+            _p: (),
+        }
+        .try_init()
+    }
+}
+
+// === impl LogArgs ===
+
+impl LogArgs {
+    /// Attempts to configure the global default `tracing` subscriber in the current scope, returning
+    /// an error if one is already set
+    ///
+    /// This method returns an error if [a global default subscriber has already been set][set], or if a
+    /// `log` logger has already been set.
+    pub fn try_init(self) -> Result<(), LogInitError> {
         use tracing_subscriber::prelude::*;
 
-        let registry = tracing_subscriber::registry().with(filter);
+        let registry = tracing_subscriber::registry();
 
-        match self {
-            LogFormat::Plain => registry.with(tracing_subscriber::fmt::layer()).try_init()?,
+        // TODO(eliza): can we serve the tokio console server on the Admin server?
+        #[cfg(feature = "tokio-console")]
+        let registry = registry.with(self.tokio_console.and_then(console_subscriber::spawn()));
+
+        match self.log_format {
+            LogFormat::Plain => registry
+                .with(tracing_subscriber::fmt::layer().with_filter(self.log_level))
+                .try_init()?,
 
             LogFormat::Json => {
                 let event_fmt = tracing_subscriber::fmt::format()
@@ -104,7 +121,8 @@ impl LogFormat {
                 // Use the JSON event formatter and the JSON field formatter.
                 let fmt = tracing_subscriber::fmt::layer()
                     .event_format(event_fmt)
-                    .fmt_fields(tracing_subscriber::fmt::format::JsonFields::default());
+                    .fmt_fields(tracing_subscriber::fmt::format::JsonFields::default())
+                    .with_filter(self.log_level);
 
                 registry.with(fmt).try_init()?
             }
@@ -116,61 +134,133 @@ impl LogFormat {
 
 // This hand-implements `Args` in order to generate some values based
 // on the command's name.
-
 impl Args for LogArgs {
     fn augment_args(cmd: Command<'_>) -> Command<'_> {
-        let level = Arg::new("log_level")
-            .long("log_level")
+        let level = Arg::new("log-level")
+            .long("log-level")
             .takes_value(true)
             .env("KUBERT_LOG")
-            .help("Configures the log level filter.")
+            .help("The filter that determines what tracing spans and events are enabled")
+            .long_help(
+                // XXX(eliza): had to use tinyurl because `clap` would line-wrap the docs.rs URL :(
+                "The filter that determines what tracing spans and events are enabled.\n\n\
+                See here for details on the accepted syntax for tracing filters:\n\
+                https://tinyurl.com/envfilter-directives",
+            )
             .default_value(default_log_filter(&cmd));
-        let format = Arg::new("log_format")
-            .long("log_format")
+        let format = Arg::new("log-format")
+            .long("log-format")
             .takes_value(true)
             .help("Which log format to use.")
-            .possible_values(LogFormat::value_variants)
+            .possible_values(
+                LogFormat::value_variants()
+                    .iter()
+                    .filter_map(LogFormat::to_possible_value),
+            )
             .default_value("plain");
 
-        cmd.arg(arg).arg(format)
+        let cmd = cmd.arg(level).arg(format);
+        #[cfg(feature = "tokio-console")]
+        let cmd = cmd.arg(
+            Arg::new("tokio-console")
+                .long("tokio-console")
+                .takes_value(false)
+                .help("Enables `tokio-console` instrumentation")
+                .long_help(
+                    "Enables `tokio-console` instrumentation.\n\n\
+            If this is set, `kubert` must be compiled with the \
+            `tokio-console` cargo feature enabled, and \
+            `RUSTFLAGS=\"--cfg tokio_unstable\"` must be set.",
+                ),
+        );
+        cmd
     }
     fn augment_args_for_update(cmd: Command<'_>) -> Command<'_> {
         Self::augment_args(cmd)
     }
 }
+
 impl FromArgMatches for LogArgs {
     fn from_arg_matches(matches: &ArgMatches) -> Result<Self, clap::Error> {
-        use clap::error::{Error, ErrorKind};
-        let filter = matches
-            .value_of("log_level")
-            .expect("arg with default value is always present");
-        LogFilter::try_new(filter)
-            .map_err(|error| Error::raw(ErrorKind::InvalidValue, error))
-            .map(Self)
+        // The `log_level` and `log_format` arguments both have default values,
+        // so we expect they will always be present.
+        let log_level = matches.value_of_t::<LogFilter>("log-level")?;
+        let log_format = matches.value_of_t::<LogFormat>("log-format")?;
+
+        #[cfg(feature = "tokio-console")]
+        let tokio_console = {
+            use clap::error::{Error, ErrorKind};
+
+            let enabled = matches.is_present("tokio-console");
+            if !cfg!(tokio_unstable) {
+                return Err(Error::raw(
+                    ErrorKind::InvalidValue,
+                    "The `--tokio-console` flag requires that `kubert` be \
+                    compiled with RUSTFLAGS=\"--cfg tokio_unstable\".",
+                ));
+            }
+            enabled
+        };
+
+        Ok(Self {
+            log_level,
+            log_format,
+            #[cfg(feature = "tokio-console")]
+            tokio_console,
+            _p: (),
+        })
     }
 
     fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), clap::Error> {
-        use clap::error::{Error, ErrorKind};
-        if let Some(filter) = matches.value_of("log_level") {
-            self.0 = LogFilter::try_new(filter)
-                .map_err(|error| Error::raw(ErrorKind::InvalidValue, error))?;
+        self.log_level = matches.value_of_t::<LogFilter>("log-level")?;
+        self.log_format = matches.value_of_t::<LogFormat>("log-format")?;
+
+        #[cfg(feature = "tokio-console")]
+        {
+            use clap::error::{Error, ErrorKind};
+
+            let enabled = matches.is_present("tokio-console");
+            if !cfg!(tokio_unstable) {
+                return Err(Error::raw(
+                    ErrorKind::InvalidValue,
+                    "The `--tokio-console` flag requires that `kubert` be \
+                    compiled with RUSTFLAGS=\"--cfg tokio_unstable\".",
+                ));
+            }
+            self.tokio_console = enabled;
         }
+
         Ok(())
     }
 }
 
+impl Default for LogArgs {
+    fn default() -> Self {
+        Self {
+            log_format: LogFormat::Plain,
+            log_level: DEFAULT_FILTER
+                .get()
+                .map(LogFormat::try_new)
+                .unwrap_or_else(|| {
+                    LogFilter::default()
+                        .add_directive(tracing_subscriber::filter::LevelFilter::WARN)
+                }),
+            #[cfg(feature = "tokio-console")]
+            tokio_console: false,
+            _p: (),
+        }
+    }
+}
+
+static DEFAULT_FILTER: OnceCell<String> = OnceCell::new();
+
 fn default_log_filter(cmd: &Command<'_>) -> &'static str {
     use once_cell::sync::OnceCell;
 
-    static DEFAULT_FILTER: OnceCell<String> = OnceCell::new();
-    DEFAULT_FILTER
-        .get_or_init(|| match cmd.get_bin_name() {
-            Some(name) => {
-                let mut filter = name.replace('-', "_");
-                filter.push_str("=info,warn");
-                filter
-            }
-            None => String::from("warn"),
-        })
-        .as_str()
+    DEFAULT_FILTER.get_or_init(|| {
+        let name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name());
+        let mut filter = name.replace('-', "_");
+        filter.push_str("=info,warn");
+        filter
+    })
 }

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -39,9 +39,7 @@ use once_cell::sync::OnceCell;
 ///     let rt = kubert::Runtime::builder()
 ///         .with_log_args(args.log)
 ///         // ...
-///         .build()
-///         .await
-///         .unwrap();
+///         .build();
 ///     # drop(rt);
 /// }
 /// ```
@@ -77,14 +75,13 @@ use once_cell::sync::OnceCell;
 ///     let rt = kubert::Runtime::builder()
 ///         .with_log_args(log_args)
 ///         // ...
-///         .build()
-///         .await
-///         .unwrap();
+///         .build();
 ///     # drop(rt);
 /// }
 /// ```
 #[derive(Debug)]
 #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
+#[must_use]
 pub struct LogArgs {
     /// The log format to use.
     pub log_format: LogFormat,
@@ -166,10 +163,40 @@ impl LogFormat {
 // === impl LogArgs ===
 
 impl LogArgs {
+    /// Sets the [`LogFormat`] used by this `LogArgs`.
+    ///
+    /// This can be used for "builder-style" configuration of `LogArgs`, or to
+    /// override values parsed from the command line using `clap`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let log_format = // ...
+    /// # Default::default();
+    ///
+    /// let log_args = kubert::LogArgs::default()
+    ///     .with_log_format(log_format);
+    /// # drop(log_args);
+    /// ```
     pub fn with_log_format(self, log_format: LogFormat) -> Self {
         Self { log_format, ..self }
     }
 
+    /// Sets the [`LogLevel`] used by this `LogArgs`.
+    ///
+    /// This can be used for "builder-style" configuration of `LogArgs`, or to
+    /// override values parsed from the command line using `clap`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let filter = // ...
+    /// # Default::default();
+    ///
+    /// let log_args = kubert::LogArgs::default()
+    ///     .with_log_level(filter);
+    /// # drop(log_args);
+    /// ```
     pub fn with_log_level(self, log_level: LogFilter) -> Self {
         Self { log_level, ..self }
     }

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -6,6 +6,8 @@ pub use tracing_subscriber::{util::TryInitError as LogInitError, EnvFilter as Lo
 
 #[cfg(feature = "clap")]
 use clap::{Arg, ArgEnum, ArgMatches, Args, Command, FromArgMatches};
+#[cfg(feature = "clap")]
+use once_cell::sync::OnceCell;
 
 /// Configures logging settings.
 ///
@@ -328,8 +330,6 @@ impl Default for LogArgs {
 static DEFAULT_FILTER: OnceCell<String> = OnceCell::new();
 
 fn default_log_filter(cmd: &Command<'_>) -> &'static str {
-    use once_cell::sync::OnceCell;
-
     DEFAULT_FILTER.get_or_init(|| {
         let name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name());
         let mut filter = name.replace('-', "_");

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -8,6 +8,79 @@ pub use tracing_subscriber::{util::TryInitError as LogInitError, EnvFilter as Lo
 use clap::{Arg, ArgEnum, ArgMatches, Args, Command, FromArgMatches};
 
 /// Configures logging settings.
+///
+/// This type may be parsed from the command line using `clap`, or configured
+/// manually. In some cases, it may be preferable to not use the default `clap`
+/// implementation for `LogArgs`, so that environment variables, default log
+/// targets, etc, may be overridden.
+///
+/// # Examples
+///
+/// If the default environment variable (`KUBERT_LOG`) and default value for the
+/// log filter (`<BINARY_NAME>=info,warn`) are desired, the
+/// `clap::FromArgMatches` impl for this type can be used directly:
+///
+/// ```rust
+/// use clap::Parser;
+///
+/// #[derive(Parser)]
+/// struct MyAppArgs {
+///     #[clap(flatten)]
+///     log: kubert::LogArgs,
+///     // ...
+/// }
+///
+/// fn main() {
+///     let args = MyAppArgs::parse();
+///
+///     let rt = kubert::Runtime::builder()
+///         .with_log_args(args.log)
+///         // ...
+///         .build()
+///         .await
+///         .unwrap();
+///     # drop(rt);
+/// }
+/// ```
+///
+/// Alternatively, a `LogArgs` instance may be constructed from user-defined values:
+///
+/// ```rust
+/// use clap::Parser;
+/// use kubert::log::{LogFilter, LogFormat};
+///
+/// #[derive(Parser)]
+/// struct MyAppArgs {
+///     // Use a different environment variable and default value than
+///     // those provided by the `FromArgMatches` impl for `LogArgs`
+///     #[clap(long, env = "MY_APP_LOG", default_value = "trace")]
+///     log_filter: LogFilter,
+///
+///     #[clap(long, env = "MY_APP_LOG_FORMAT", default_value = "json")]
+///     log_format: LogFormat,
+///     
+/// }
+///
+/// fn main() {
+///     let args = MyAppArgs::parse();
+///
+///      // Construct a `LogArgs` from the values we parsed using our
+///      // custom configuration:
+///     let log_args = kubert::LogArgs {
+///         log_filter: args.log_filter,
+///         log_format: args.log_format,
+///         ..Default::default()
+///     };
+///
+///     let rt = kubert::Runtime::builder()
+///         .with_log_args(log_args)
+///         // ...
+///         .build()
+///         .await
+///         .unwrap();
+///     # drop(rt);
+/// }
+/// ```
 #[derive(Debug)]
 #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
 pub struct LogArgs {

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -114,7 +114,8 @@ impl<S> Builder<S> {
         self.log = Some(LogArgs {
             log_level: filter,
             log_format: format,
-            #[cfg(feature = "tokio-console")]
+
+            #[cfg(all(tokio_unstable, feature = "tokio-console"))]
             tokio_console: false,
             _p: (),
         });

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -507,7 +507,7 @@ impl Runtime<NoServer> {
 
         // Set the admin readiness to succeed once all initilization handles have been released.
         let ready = admin.readiness();
-        tokio::spawn(async move {
+        crate::spawn_named("kubert::ready", async move {
             initialized.initialized().await;
             ready.set(true);
             tracing::debug!("initialized");

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -148,7 +148,8 @@ impl Bound {
             tls_certs,
         } = self;
 
-        let task = tokio::spawn(
+        let task = crate::spawn_named(
+            "kubert::server",
             accept_loop(tcp, drain, service, tls_key, tls_certs)
                 .instrument(info_span!("server", port = %local_addr.port())),
         );
@@ -219,7 +220,8 @@ async fn accept_loop<S, B>(
             }
         };
 
-        tokio::spawn(
+        crate::spawn_named(
+            "kubert::conn",
             serve_conn(
                 socket,
                 drain.clone(),


### PR DESCRIPTION
This branch adds initial support for setting up the Tokio console to
track tasks in a Kubert controller. In order to do so, I added a new
`LogArgs` struct in the `log` module to represent a logging
configuration that can be parsed using `clap`, including a flag for
enabling `tokio-console` support. When this flag is present, and the
requisite `kubert` feature and `RUSTFLAGS="--cfg tokio_unstable"` are
enabled, the Tokio console server is enabled.

Additionally, the new `LogArgs` struct handles parsing the `LogFormat`
and `tracing_subscriber::EnvFilter` arguments. The `LogArgs` type uses a
custom `clap::FromArgs` implementation so that the default value for the
filter can include the name of the binary itself.

Finally, I added support for spawning named tasks using the unstable
`tokio::task::Builder` API, when the `tokio_unstable` cfg is enabled.
These task names will show up in the console when the cfg is enabled.