### PR TITLE
Update to kube v0.74

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies.kube]
-version = "0.73"
+version = "0.74"
 default-features = false
 features = [
     "client",

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
                         let mut new = std::collections::HashSet::new();
                         for pod in pods.into_iter() {
                             let namespace = pod.namespace().unwrap();
-                            let name = pod.name();
+                            let name = pod.name_unchecked();
                             let k = (namespace.clone(), name.clone());
                             if !known.contains(&k) {
                                 tracing::info!(%namespace, %name, "added")
@@ -114,7 +114,7 @@ async fn main() -> Result<()> {
 
                     Event::Applied(pod) => {
                         let namespace = pod.namespace().unwrap();
-                        let name = pod.name();
+                        let name = pod.name_unchecked();
                         if known.insert((namespace.clone(), name.clone())) {
                             tracing::info!(%namespace, %name, "added");
                         } else {
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
 
                     Event::Deleted(pod) => {
                         let namespace = pod.namespace().unwrap();
-                        let name = pod.name();
+                        let name = pod.name_unchecked();
                         tracing::info!(%namespace, %name, "deleted");
                         known.remove(&(namespace, name));
                     }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -109,18 +109,18 @@ optional = true
 default-features = false
 
 [dependencies.kube-client]
-version = "0.73"
+version = "0.74"
 optional = true
 default-features = false
 features = ["client", "config"]
 
 [dependencies.kube-core]
-version = "0.73"
+version = "0.74"
 optional = true
 default-features = false
 
 [dependencies.kube-runtime]
-version = "0.73"
+version = "0.74"
 optional = true
 default-features = false
 
@@ -137,7 +137,7 @@ features = [
 ]
 
 [dev-dependencies]
-kube = { version = "0.73", default-features = false, features = ["runtime"] }
+kube = { version = "0.74", default-features = false, features = ["runtime"] }
 k8s-openapi = { version = "0.15", default-features = false, features = ["v1_23"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"

--- a/kubert/src/index.rs
+++ b/kubert/src/index.rs
@@ -77,7 +77,7 @@ pub async fn namespaced<T, R>(
                 let namespace = resource
                     .namespace()
                     .expect("resource must have a namespace");
-                let name = resource.name();
+                let name = resource.name_unchecked();
 
                 keys.entry(namespace)
                     .or_insert_with(HashSet::new)
@@ -90,7 +90,7 @@ pub async fn namespaced<T, R>(
                 let namespace = resource
                     .namespace()
                     .expect("resource must have a namespace");
-                let name = resource.name();
+                let name = resource.name_unchecked();
 
                 if let Entry::Occupied(mut entry) = keys.entry(namespace.clone()) {
                     entry.get_mut().remove(&name);
@@ -110,7 +110,7 @@ pub async fn namespaced<T, R>(
                     let namespace = resource
                         .namespace()
                         .expect("resource must have a namespace");
-                    let name = resource.name();
+                    let name = resource.name_unchecked();
 
                     if let Some(names) = removed.get_mut(&namespace) {
                         names.remove(&name);
@@ -153,12 +153,12 @@ pub async fn cluster<T, R>(
         tracing::trace!(?event);
         match event {
             Event::Applied(resource) => {
-                keys.insert(resource.name());
+                keys.insert(resource.name_unchecked());
                 index.write().apply(resource);
             }
 
             Event::Deleted(resource) => {
-                let name = resource.name();
+                let name = resource.name_unchecked();
                 keys.remove(&name);
                 index.write().delete(name);
             }
@@ -168,7 +168,7 @@ pub async fn cluster<T, R>(
                 // the index, keeping track of which resources need to be removed from the index.
                 let mut removed = keys.clone();
                 for resource in resources.iter() {
-                    let name = resource.name();
+                    let name = resource.name_unchecked();
                     removed.remove(&name);
                     keys.insert(name);
                 }
@@ -308,7 +308,7 @@ mod tests {
 
     impl<T: Resource> IndexClusterResource<T> for ClusterCache {
         fn apply(&mut self, resource: T) {
-            self.0.insert(resource.name());
+            self.0.insert(resource.name_unchecked());
         }
 
         fn delete(&mut self, name: String) {
@@ -321,7 +321,7 @@ mod tests {
             let namespace = resource
                 .namespace()
                 .expect("resource must have a namespace");
-            let name = resource.name();
+            let name = resource.name_unchecked();
             self.0
                 .entry(namespace)
                 .or_insert_with(HashSet::new)


### PR DESCRIPTION
kube v0.74 deprecates `ResourceExt::name`. We replace our uses with
`ResourceExt::name_unchecked`, as we are handling resources from the API
server (and so a name must be set).