### PR TITLE
server: Set a 2s request header timeout

### DIFF
--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -105,7 +105,7 @@ impl Builder {
         let server = hyper::server::Server::try_bind(&addr)?
             // Allow weird clients (like netcat).
             .http1_half_close(true)
-            // Prevent port scanners, etc, from holding connections ope.n
+            // Prevent port scanners, etc, from holding connections open.
             .http1_header_read_timeout(Duration::from_secs(2))
             // Use a small buffer, since we don't really transfer much data.
             .http1_max_buf_size(8 * 1024);
@@ -141,7 +141,7 @@ impl Bound {
                         "/live" => future::ok(handle_live(req)),
                         "/ready" => future::ok(handle_ready(&ready, req)),
                         _ => future::ok::<_, hyper::Error>(
-                            hyper::Response::builder()
+                            Response::builder()
                                 .status(hyper::StatusCode::NOT_FOUND)
                                 .body(hyper::Body::default())
                                 .unwrap(),

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -274,7 +274,10 @@ async fn serve_conn<S, B>(
     // Serve the HTTP connection and wait for the drain signal. If a drain is
     // signaled, tell the HTTP connection to terminate gracefully when in-flight
     // requests have completed.
-    let mut conn = hyper::server::conn::Http::new().serve_connection(socket, service);
+    let mut conn = hyper::server::conn::Http::new()
+        // Prevent port scanners, etc, from holding connections open.
+        .http1_header_read_timeout(std::time::Duration::from_secs(2))
+        .serve_connection(socket, service);
     let res = tokio::select! {
         biased;
         res = &mut conn => res,


### PR DESCRIPTION
The admin server sets a 2s request header timeout to prevent clients
from holding connections open indefinitely. No such timeout is
configured on the admission controller server. This change updates the
`server` module to apply a 2s request header timeout.