### PR TITLE
Update to clap v4

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies.clap]
-version = "3"
+version = "4"
 default-features = false
 features = ["derive", "env", "std"]
 

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -9,7 +9,7 @@ use kube::{api::ListParams, runtime::watcher::Event, ResourceExt};
 use tokio::time;
 use tracing::Instrument;
 
-#[derive(Parser)]
+#[derive(Clone, Parser)]
 #[clap(version)]
 struct Args {
     /// The tracing filter used for logs

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."
@@ -115,7 +115,7 @@ tower-service = { version = "0.3.1", optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 [dependencies.clap]
-version = "3.1.0"
+version = "4"
 optional = true
 default-features = false
 features = ["derive", "std"]

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -57,7 +57,7 @@ impl std::str::FromStr for LogFilter {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let filter = s.parse::<EnvFilter>()?;
+        let filter = EnvFilter::builder().with_regex(false).parse(s)?;
         Ok(Self(filter.into()))
     }
 }
@@ -143,6 +143,12 @@ impl<S> Filter<S> for LogFilter {
     #[inline]
     fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
         self.0.on_close(id, ctx);
+    }
+}
+
+impl std::fmt::Display for LogFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -1,8 +1,15 @@
 //! Configures the global default tracing subscriber
 
+use std::sync::Arc;
 use thiserror::Error;
+use tracing::{metadata::LevelFilter, span, subscriber::Interest, Metadata, Subscriber};
+use tracing_subscriber::{
+    filter::ParseError,
+    layer::{Context, Filter},
+    EnvFilter, Layer,
+};
 
-pub use tracing_subscriber::{util::TryInitError as LogInitError, EnvFilter as LogFilter};
+pub use tracing_subscriber::util::TryInitError as LogInitError;
 
 /// Configures whether logs should be emitted in plaintext (the default) or as JSON-encoded
 /// messages
@@ -16,11 +23,128 @@ pub enum LogFormat {
     Json,
 }
 
+/// Configures the global default tracing filters.
+///
+/// A cloneable version of [`tracing_subscriber::EnvFilter`].
+#[derive(Clone, Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "log")))]
+pub struct LogFilter(Arc<EnvFilter>);
+
 /// Indicates that an invalid log format was specified
 #[derive(Debug, Error)]
 #[error("invalid log level: {0} must be 'plain' or 'json'")]
 #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
 pub struct InvalidLogFormat(String);
+
+// ==== impl LogFilter ===
+
+impl LogFilter {
+    /// Returns a new `LogFilter` from the value of the `RUST_LOG` environment
+    /// variable, ignoring any invalid filter directives.
+    ///
+    /// If the environment variable is empty or not set, or if it contains only
+    /// invalid directives, a default directive enabling the [`ERROR`] level is
+    /// added.
+    ///
+    /// [`ERROR`]: tracing::Level::ERROR
+    #[inline]
+    pub fn from_default_env() -> Self {
+        Self(EnvFilter::from_default_env().into())
+    }
+}
+
+impl std::str::FromStr for LogFilter {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let filter = s.parse::<EnvFilter>()?;
+        Ok(Self(filter.into()))
+    }
+}
+
+impl<S: Subscriber> Layer<S> for LogFilter {
+    #[inline]
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        Layer::<S>::register_callsite(&*self.0, metadata)
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        self.0.max_level_hint()
+    }
+
+    #[inline]
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        self.0.enabled(metadata, ctx)
+    }
+
+    #[inline]
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        self.0.on_new_span(attrs, id, ctx)
+    }
+
+    #[inline]
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        self.0.on_record(id, values, ctx);
+    }
+
+    #[inline]
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        self.0.on_enter(id, ctx);
+    }
+
+    #[inline]
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        self.0.on_exit(id, ctx);
+    }
+
+    #[inline]
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        self.0.on_close(id, ctx);
+    }
+}
+
+impl<S> Filter<S> for LogFilter {
+    #[inline]
+    fn enabled(&self, meta: &Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+        self.0.enabled(meta, ctx.clone())
+    }
+
+    #[inline]
+    fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
+        Filter::<S>::callsite_enabled(&*self.0, meta)
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        self.0.max_level_hint()
+    }
+
+    #[inline]
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        self.0.on_new_span(attrs, id, ctx)
+    }
+
+    #[inline]
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        self.0.on_record(id, values, ctx);
+    }
+
+    #[inline]
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        self.0.on_enter(id, ctx);
+    }
+
+    #[inline]
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        self.0.on_exit(id, ctx);
+    }
+
+    #[inline]
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        self.0.on_close(id, ctx);
+    }
+}
 
 // === impl LogFormat ===
 


### PR DESCRIPTION
Clap now requires that argument values are cloneable, which prevents us from using a `tracing_subcriber::EnvFilter` directly. The `LogFilter` type is changed to wrap a shareable heap-allocated `EnvFilter`.

This change bumps kubert's version to v0.11.0.