### PR TITLE
docs: fix `index` module not being present on docs.rs

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -84,16 +84,8 @@ shutdown = [
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 features = [
-    "admin",
-    "client",
-    "errors",
-    "initialized",
-    "log",
-    "requeue",
-    "runtime",
-    "server",
-    "shutdown",
     "k8s-openapi/v1_25",
 ]
 


### PR DESCRIPTION
Currently, the docs.rs documentation for `kubert` doesn't show the `kubert::index` module, or any of its contents (such as the `Index{Cluster, Namespaced}Resource` traits).

For example, here's the current docs from https://docs.rs/kubert/0.10.0/kubert/index.html

![image](https://user-images.githubusercontent.com/2796466/193113215-ff8e7b58-56e7-477d-b10f-d5a54b467d4c.png)

This is because the crate's docs.rs metadata currently enables a specific list of features, which doesn't include the `index` feature. Presumably, the list of features to enable when building docs was not modified when the `index` module was added.

This commit fixes this by changing the docs.rs metadata so that `--all-features` is passed instead of a list of feature flags. This way, not only is the `index` module now present, but also, if any new feature flags are added, the docs.rs metadata won't need to be modified again.

Note that the `index` module is now present:

![image](https://user-images.githubusercontent.com/2796466/193113505-bbf0b152-ef2b-4557-88b7-603152ca8f90.png)


We still pass a list of explicit feature flags to enable `k8s-openapi/v1_25`, since `--all-features` only effects *`kubert`'s* features, and not those of dependencies.