### PR TITLE
lease: A distributed, cooperative lock

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -49,11 +49,13 @@ jobs:
       - run: just test-cluster-create
       - run: just test-cluster-run-watch-pods --log-level=debug
       - run: just test-cluster-create-ns
-      - name: Run test-cluster-run-watch-pods with impersonation
+      - name: Run just test-cluster-run-watch-pods with impersonation
         run: |
           just test-cluster-run-watch-pods --log-level=debug \
             --as=system:serviceaccount:${KUBERT_TEST_NS}:watch-pods \
             --kubeconfig=$HOME/.kube/config
+      - run: just build-test-lease
+      - run: just test-lease
 
   in-cluster:
     strategy:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -43,6 +43,7 @@ jobs:
           - errors
           - index
           - initialized
+          - lease
           - log
           - requeue
           - runtime

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,15 +11,19 @@ release = false
 
 [dev-dependencies]
 anyhow = "1"
+chrono = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false }
+maplit = "1"
+rand = "0.8"
 regex = "1"
 thiserror = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter"] }
 
 [dev-dependencies.clap]
 version = "4"
 default-features = false
-features = ["derive", "env", "std"]
+features = ["derive", "help", "env", "std"]
 
 [dev-dependencies.k8s-openapi]
 version = "0.16"
@@ -34,7 +38,7 @@ features = ["client", "derive", "native-tls", "runtime"]
 [dev-dependencies.kubert]
 path = "../kubert"
 default-features = false
-features = ["clap", "runtime"]
+features = ["clap", "lease", "runtime"]
 
 [dev-dependencies.tokio]
 version = "1"
@@ -43,3 +47,7 @@ features = ["macros", "parking_lot", "rt", "rt-multi-thread", "time"]
 [[example]]
 name = "watch-pods"
 path = "watch_pods.rs"
+
+[[example]]
+name = "lease"
+path = "lease.rs"

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<()> {
 
         Command::Get { name } => tokio::spawn(async move {
             let lease = kubert::Lease::init(api, name, field_manager).await?;
-            match lease.sync().await? {
+            match lease.claimed().await? {
                 Some(claim) => print_claim(&claim, &identity),
                 None => println!("? Unclaimed"),
             }

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -1,0 +1,257 @@
+#![deny(warnings, rust_2018_idioms)]
+#![forbid(unsafe_code)]
+
+use anyhow::{bail, Result};
+use k8s_openapi::{api::coordination::v1 as coordv1, apimachinery::pkg::apis::meta::v1 as metav1};
+use kube::ResourceExt;
+use tokio::time;
+
+#[derive(Clone, clap::Parser)]
+#[clap(version)]
+struct Args {
+    /// The tracing filter used for logs
+    #[arg(long, env = "KUBERT_EXAMPLE_LOG", default_value = "lease=info,warn")]
+    log_level: kubert::LogFilter,
+
+    /// The logging format
+    #[arg(long, default_value = "plain")]
+    log_format: kubert::LogFormat,
+
+    #[clap(flatten)]
+    client: kubert::ClientArgs,
+
+    #[clap(flatten)]
+    admin: kubert::AdminArgs,
+
+    #[arg(long, default_value = "kubert-examples")]
+    field_manager: String,
+
+    #[arg(short, long, env = "LOGNAME", default_value = "default")]
+    identity: String,
+
+    #[arg(short, long, default_value = "default")]
+    namespace: String,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Clone, clap::Parser)]
+enum Command {
+    /// Create a Lease
+    Create { name: String },
+
+    /// Try to claim a Lease
+    Claim {
+        #[arg(long, default_value = "30s")]
+        duration: Timeout,
+
+        #[arg(long, default_value = "1s")]
+        renew_grace_period: Timeout,
+
+        name: String,
+    },
+
+    /// Get the status of a Lease
+    Get { name: String },
+
+    /// Release a lease if it is currently held by the given identity
+    Abdicate { name: String },
+
+    Run {
+        #[arg(long, default_value = "30s")]
+        duration: Timeout,
+
+        #[arg(long, default_value = "1s")]
+        renew_grace_period: Timeout,
+
+        name: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    use clap::Parser;
+
+    let Args {
+        log_level,
+        log_format,
+        client,
+        admin,
+        field_manager,
+        identity,
+        namespace,
+        command,
+    } = Args::parse();
+
+    // Configure a runtime with:
+    // - a Kubernetes client
+    // - an admin server with /live and /ready endpoints
+    // - a tracing (logging) subscriber
+    let rt = kubert::Runtime::builder()
+        .with_log(log_level, log_format)
+        .with_admin(admin)
+        .with_client(client)
+        .build()
+        .await?;
+
+    let api = kube::Api::namespaced(rt.client(), &namespace);
+    let shutdown = rt.shutdown_handle();
+    let task = match command {
+        Command::Create { name } => tokio::spawn(async move {
+            let lease = api
+                .create(
+                    &Default::default(),
+                    &coordv1::Lease {
+                        metadata: metav1::ObjectMeta {
+                            name: Some(name),
+                            namespace: Some(namespace),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            println!("Created lease: {}", lease.name_unchecked());
+            Ok::<_, kubert::lease::Error>(0)
+        }),
+
+        Command::Get { name } => tokio::spawn(async move {
+            let lease = kubert::Lease::init(api, name, field_manager).await?;
+            match lease.sync().await? {
+                Some(claim) => print_claim(&claim, &identity),
+                None => println!("? Unclaimed"),
+            }
+            Ok::<_, kubert::lease::Error>(0)
+        }),
+
+        Command::Claim {
+            duration: Timeout(lease_duration),
+            renew_grace_period: Timeout(renew_grace_period),
+            name,
+        } => tokio::spawn(async move {
+            let params = kubert::lease::ClaimParams {
+                lease_duration,
+                renew_grace_period,
+            };
+
+            let lease = kubert::Lease::init(api, name, field_manager).await?;
+            let claim = lease.ensure_claimed(&identity, &params).await?;
+            print_claim(&claim, &identity);
+
+            Ok::<_, kubert::lease::Error>(if claim.is_current_for(&identity) {
+                0
+            } else {
+                1
+            })
+        }),
+
+        Command::Abdicate { name } => tokio::spawn(async move {
+            let released = kubert::Lease::init(api, name, field_manager)
+                .await?
+                .abdicate(&*identity)
+                .await?;
+            if released {
+                println!("Abdicated");
+            } else {
+                println!("Not abdicated");
+            }
+
+            Ok::<_, kubert::lease::Error>(if released { 0 } else { 1 })
+        }),
+
+        Command::Run {
+            duration: Timeout(lease_duration),
+            renew_grace_period: Timeout(renew_grace_period),
+            name,
+        } => tokio::spawn(async move {
+            let params = kubert::lease::ClaimParams {
+                lease_duration,
+                renew_grace_period,
+            };
+
+            let lease = kubert::Lease::init(api, name, field_manager).await?;
+            let (mut claims, task) = lease.spawn_claimant(identity.clone(), params).await?;
+            loop {
+                print_claim(&*claims.borrow_and_update(), &identity);
+
+                let shutdown = shutdown.clone();
+                tokio::select! {
+                    biased;
+                    _ = shutdown.signaled() => {
+                        return Ok(0);
+                    }
+                    res = claims.changed() => {
+                        if res.is_err() {
+                            task.await.expect("task")?;
+                            return Ok(0);
+                        }
+                    }
+                }
+            }
+        }),
+    };
+
+    tokio::select! {
+        // Block the main thread on the shutdown signal. This won't complete until the watch stream
+        // stops (after pending Pod updates are logged). If a second signal is received before the watch
+        // stream completes, the future fails.
+        res = rt.run() => {
+            if let Err(error) = res {
+                bail!(error);
+            }
+        }
+
+        // If the watch stream completes, exit gracefully
+        res = task => match res {
+            Ok(Ok(0)) => {}
+            Ok(Ok(code)) => std::process::exit(code),
+            Err(error) => bail!(error),
+            Ok(Err(error)) => bail!(error),
+        },
+    }
+
+    Ok(())
+}
+
+fn print_claim(claim: &kubert::lease::Claim, identity: &str) {
+    let holder = &claim.holder;
+    let expiry = claim
+        .expiry
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    if !claim.is_current() {
+        println!("! Expired for {holder} at {expiry}");
+        return;
+    }
+
+    println!(
+        "{} Claimed by {holder} until {expiry}",
+        if claim.holder == identity { "+" } else { "-" }
+    );
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Timeout(time::Duration);
+
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+#[error("invalid duration")]
+struct InvalidTimeout;
+
+impl std::str::FromStr for Timeout {
+    type Err = InvalidTimeout;
+
+    fn from_str(s: &str) -> Result<Self, InvalidTimeout> {
+        let re = regex::Regex::new(r"^\s*(\d+)(ms|s|m)?\s*$").expect("duration regex");
+        let cap = re.captures(s).ok_or(InvalidTimeout)?;
+        let magnitude = cap[1].parse().map_err(|_| InvalidTimeout)?;
+        let t = match cap.get(2).map(|m| m.as_str()) {
+            None if magnitude == 0 => time::Duration::from_millis(0),
+            Some("ms") => time::Duration::from_millis(magnitude),
+            Some("s") => time::Duration::from_secs(magnitude),
+            Some("m") => time::Duration::from_secs(magnitude * 60),
+            _ => return Err(InvalidTimeout),
+        };
+        Ok(Self(t))
+    }
+}

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -178,7 +178,7 @@ async fn main() -> Result<()> {
             let lease = kubert::LeaseManager::init(api, name)
                 .await?
                 .with_field_manager(field_manager);
-            let (mut claims, task) = lease.spawn_claimant(identity.clone(), params).await?;
+            let (mut claims, task) = lease.spawn(&identity, params).await?;
             loop {
                 print_claim(&*claims.borrow_and_update(), &identity);
 

--- a/examples/tests/lease.rs
+++ b/examples/tests/lease.rs
@@ -234,7 +234,7 @@ async fn renews() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn abidcates() {
+async fn vacates() {
     let handle = Handle::setup().await;
 
     let lease = handle.init_new().await;
@@ -244,7 +244,7 @@ async fn abidcates() {
     };
     let claim0 = lease.ensure_claimed("id", &params).await.expect("claim");
     assert!(claim0.is_current_for("id"));
-    let released = lease.abdicate("id").await.expect("release");
+    let released = lease.vacate("id").await.expect("release");
     assert!(released);
 
     // Inspect the lease resource to verify that it has all expected fields.

--- a/examples/tests/lease.rs
+++ b/examples/tests/lease.rs
@@ -1,0 +1,366 @@
+#![deny(warnings, rust_2018_idioms)]
+
+use k8s_openapi::{
+    api::coordination::v1 as coordv1,
+    apimachinery::pkg::apis::meta::v1::{self as metav1},
+};
+use kubert::Lease;
+use maplit::{btreemap, convert_args};
+use tokio::time;
+
+type Api = kube::Api<coordv1::Lease>;
+
+macro_rules! assert_time_eq {
+    ($a:expr, $b:expr $(,)?) => {
+        assert_eq!(
+            $a.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            $b.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        );
+    };
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn exclusive() {
+    let handle = Handle::setup().await;
+
+    // Create a lease instance and claim it.
+
+    let lease0 = handle.init_new().await;
+    let params = kubert::lease::ClaimParams {
+        lease_duration: time::Duration::from_secs(3),
+        ..Default::default()
+    };
+    let claim0 = lease0
+        .ensure_claimed("alice", &params)
+        .await
+        .expect("claim");
+    assert!(claim0.is_current_for("alice"));
+
+    // Create another lease instance and try to claim it--the prior lease should
+    // have precedence.
+
+    let lease1 = handle.init_new().await;
+    let claim1 = lease1.ensure_claimed("bob", &params).await.expect("claim");
+    assert_eq!(claim0.holder, claim1.holder);
+    assert_eq!(claim0.expiry.timestamp(), claim1.expiry.timestamp());
+    assert!(claim0.is_current_for("alice"));
+    assert!(claim1.is_current_for("alice"));
+    assert!(!claim0.is_current_for("bob"));
+    assert!(!claim1.is_current_for("bob"));
+
+    // Inspect the lease resource to verify that it has all expected fields.
+    let rsrc = handle.get().await;
+    assert_eq!(
+        rsrc.holder_identity.as_deref().expect("holderIdentity"),
+        "alice"
+    );
+    assert_time_eq!(
+        rsrc.renew_time
+            .as_ref()
+            .map(|metav1::MicroTime(t)| t)
+            .expect("renewTime"),
+        claim0.expiry - chrono::Duration::from_std(params.lease_duration).unwrap()
+    );
+    // Since we just acquired this, the acquire time and renew time are the
+    // same.
+    assert_time_eq!(
+        rsrc.acquire_time.as_ref().unwrap().0,
+        rsrc.renew_time.as_ref().unwrap().0
+    );
+    assert_eq!(
+        time::Duration::from_secs(
+            rsrc.lease_duration_seconds
+                .expect("leaseDurationSeconds")
+                .try_into()
+                .unwrap()
+        ),
+        params.lease_duration
+    );
+    assert_eq!(rsrc.lease_transitions, Some(1));
+
+    handle.delete().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn expires() {
+    let handle = Handle::setup().await;
+
+    let lease = handle.init_new().await;
+    let params = kubert::lease::ClaimParams {
+        lease_duration: time::Duration::from_secs(3),
+        ..Default::default()
+    };
+    let claim0 = lease.ensure_claimed("alice", &params).await.expect("claim");
+    assert!(claim0.is_current_for("alice"));
+
+    // Wait for the claim to expire.
+    claim0.expire().await;
+
+    // Claiming with another identity should succeed.
+    let claim1 = lease.ensure_claimed("bob", &params).await.expect("claim");
+    assert!(claim1.is_current_for("bob"));
+
+    // Inspect the lease resource to verify that it has all expected fields.
+    let rsrc = handle.get().await;
+    assert_eq!(
+        rsrc.holder_identity.as_deref().expect("holderIdentity"),
+        "bob"
+    );
+    assert_time_eq!(
+        rsrc.renew_time
+            .as_ref()
+            .map(|metav1::MicroTime(t)| t)
+            .expect("renewTime"),
+        claim1.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+    );
+    // Since we just acquired this, the acquire time and renew time are the
+    // same.
+    assert_eq!(rsrc.acquire_time, rsrc.renew_time);
+    assert_eq!(
+        time::Duration::from_secs(
+            rsrc.lease_duration_seconds
+                .expect("leaseDurationSeconds")
+                .try_into()
+                .unwrap()
+        ),
+        params.lease_duration
+    );
+    assert_eq!(rsrc.lease_transitions, Some(2));
+
+    handle.delete().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn renews() {
+    let handle = Handle::setup().await;
+
+    let lease = handle.init_new().await;
+    let params = kubert::lease::ClaimParams {
+        lease_duration: time::Duration::from_secs(8),
+        renew_grace_period: time::Duration::from_secs(5),
+    };
+    let claim0 = lease.ensure_claimed("alice", &params).await.expect("claim");
+    assert!(claim0.is_current_for("alice"));
+
+    tokio::time::sleep(time::Duration::from_secs(1)).await;
+
+    // Trying to claim again does not change the expiry.
+    let claim1 = lease.ensure_claimed("alice", &params).await.expect("claim");
+    assert_eq!(claim0, claim1);
+
+    // Wait for the claim to be renewable.
+    claim0.expire_with_grace(params.renew_grace_period).await;
+
+    // Claiming now (before the expiry) should update the expiry.
+    let claim2 = lease.ensure_claimed("alice", &params).await.expect("claim");
+    assert!(claim2.is_current_for("alice"));
+    assert_ne!(claim2, claim0);
+
+    // Inspect the lease resource to verify that it has all expected fields.
+    let rsrc = handle.get().await;
+    assert_eq!(
+        rsrc.holder_identity.as_deref().expect("holderIdentity"),
+        "alice"
+    );
+    assert_time_eq!(
+        rsrc.renew_time
+            .as_ref()
+            .map(|metav1::MicroTime(t)| t)
+            .expect("renewTime"),
+        claim2.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+    );
+    assert_time_eq!(
+        rsrc.acquire_time
+            .as_ref()
+            .map(|metav1::MicroTime(t)| t)
+            .expect("renewTime"),
+        claim0.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+    );
+    assert_eq!(
+        time::Duration::from_secs(
+            rsrc.lease_duration_seconds
+                .expect("leaseDurationSeconds")
+                .try_into()
+                .unwrap()
+        ),
+        params.lease_duration
+    );
+    assert_eq!(rsrc.lease_transitions, Some(1));
+
+    // Wait for the claim to expire completely.
+    claim2.expire().await;
+
+    // Create a new lease that does not share internal state and use it to claim the lease for Bob.
+    let lease1 = handle.init_new().await;
+    let claim3 = lease1.ensure_claimed("bob", &params).await.expect("claim");
+    assert!(claim3.is_current_for("bob"));
+
+    // The original lease must
+    let claim4 = lease.ensure_claimed("alice", &params).await.expect("claim");
+    assert!(claim4.is_current_for("bob"));
+
+    // Inspect the lease resource to verify that it has all expected fields.
+    let rsrc = handle.get().await;
+    assert_eq!(
+        rsrc.holder_identity.as_deref().expect("holderIdentity"),
+        "bob"
+    );
+    assert_time_eq!(
+        rsrc.renew_time
+            .as_ref()
+            .map(|metav1::MicroTime(t)| t)
+            .expect("renewTime"),
+        claim3.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+    );
+    assert_time_eq!(
+        rsrc.acquire_time
+            .as_ref()
+            .map(|metav1::MicroTime(t)| t)
+            .expect("renewTime"),
+        claim3.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+    );
+    assert_eq!(
+        time::Duration::from_secs(
+            rsrc.lease_duration_seconds
+                .expect("leaseDurationSeconds")
+                .try_into()
+                .unwrap()
+        ),
+        params.lease_duration
+    );
+    assert_eq!(rsrc.lease_transitions, Some(2));
+
+    handle.delete().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn abidcates() {
+    let handle = Handle::setup().await;
+
+    let lease = handle.init_new().await;
+    let params = kubert::lease::ClaimParams {
+        lease_duration: time::Duration::from_secs(3),
+        ..Default::default()
+    };
+    let claim0 = lease.ensure_claimed("id", &params).await.expect("claim");
+    assert!(claim0.is_current_for("id"));
+    let released = lease.abdicate("id").await.expect("release");
+    assert!(released);
+
+    // Inspect the lease resource to verify that it has all expected fields.
+    let rsrc = handle.get().await;
+    assert_eq!(rsrc.holder_identity, None,);
+    assert_eq!(rsrc.renew_time, None,);
+    assert_eq!(rsrc.acquire_time, None);
+    assert_eq!(rsrc.lease_duration_seconds, None);
+    assert_eq!(rsrc.lease_transitions, Some(1));
+
+    handle.delete().await;
+}
+
+// === Utils ===
+
+struct Handle {
+    api: Api,
+    name: String,
+    _guard: tracing::subscriber::DefaultGuard,
+}
+
+impl Handle {
+    const NS: &'static str = "default";
+    const FIELD_MANAGER: &'static str = "kubert-test";
+    const LABEL: &'static str = "kubert.olix0r.net/test";
+
+    async fn setup() -> Self {
+        let _guard = Self::init_tracing();
+        let client = kube::Client::try_default().await.expect("client");
+        let api = Api::namespaced(client, Self::NS);
+        let name = Self::rand_name("kubert-test");
+        api.create(
+            &Default::default(),
+            &coordv1::Lease {
+                metadata: metav1::ObjectMeta {
+                    name: Some(name.clone()),
+                    namespace: Some(Self::NS.to_string()),
+                    labels: Some(convert_args!(btreemap!(
+                        Self::LABEL => std::thread::current().name().expect("thread name"),
+                    ))),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create lease");
+        Handle { api, name, _guard }
+    }
+
+    async fn init_new(&self) -> Lease {
+        Lease::init(self.api.clone(), &self.name, Self::FIELD_MANAGER)
+            .await
+            .expect("lease must initialize")
+    }
+
+    async fn get(&self) -> coordv1::LeaseSpec {
+        self.api
+            .get(&self.name)
+            .await
+            .expect("get")
+            .spec
+            .expect("spec")
+    }
+
+    async fn delete(self) {
+        self.api
+            .delete(&self.name, &Default::default())
+            .await
+            .expect("delete");
+    }
+
+    fn rand_name(base: impl std::fmt::Display) -> String {
+        use rand::Rng;
+
+        struct LowercaseAlphanumeric;
+
+        // Modified from `rand::distributions::Alphanumeric`
+        //
+        // Copyright 2018 Developers of the Rand project
+        // Copyright (c) 2014 The Rust Project Developers
+        impl rand::distributions::Distribution<u8> for LowercaseAlphanumeric {
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> u8 {
+                const RANGE: u32 = 26 + 10;
+                const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+                loop {
+                    let var = rng.next_u32() >> (32 - 6);
+                    if var < RANGE {
+                        return CHARSET[var as usize];
+                    }
+                }
+            }
+        }
+
+        let suffix = rand::thread_rng()
+            .sample_iter(&LowercaseAlphanumeric)
+            .take(5)
+            .map(char::from)
+            .collect::<String>();
+        format!("{}-{}", base, suffix)
+    }
+
+    fn init_tracing() -> tracing::subscriber::DefaultGuard {
+        tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .with_test_writer()
+                .with_thread_names(true)
+                // .without_time()
+                .with_env_filter(
+                    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                        "trace,tower=info,hyper=info,kube=info,h2=info"
+                            .parse()
+                            .unwrap()
+                    }),
+                )
+                .finish(),
+        )
+    }
+}

--- a/examples/tests/lease.rs
+++ b/examples/tests/lease.rs
@@ -4,7 +4,7 @@ use k8s_openapi::{
     api::coordination::v1 as coordv1,
     apimachinery::pkg::apis::meta::v1::{self as metav1},
 };
-use kubert::Lease;
+use kubert::LeaseManager;
 use maplit::{btreemap, convert_args};
 use tokio::time;
 
@@ -268,7 +268,6 @@ struct Handle {
 
 impl Handle {
     const NS: &'static str = "default";
-    const FIELD_MANAGER: &'static str = "kubert-test";
     const LABEL: &'static str = "kubert.olix0r.net/test";
 
     async fn setup() -> Self {
@@ -295,8 +294,8 @@ impl Handle {
         Handle { api, name, _guard }
     }
 
-    async fn init_new(&self) -> Lease {
-        Lease::init(self.api.clone(), &self.name, Self::FIELD_MANAGER)
+    async fn init_new(&self) -> LeaseManager {
+        LeaseManager::init(self.api.clone(), &self.name)
             .await
             .expect("lease must initialize")
     }

--- a/justfile
+++ b/justfile
@@ -74,6 +74,7 @@ doc *flags:
 build-test *flags:
     {{ cargo }} test --no-run \
         --workspace --frozen {{ _features }} \
+        --exclude=kubert-examples \
         {{ if build-type == "release" { "--release" } else { "" } }} \
         {{ flags }} \
         {{ _fmt }}
@@ -82,6 +83,7 @@ build-test *flags:
 test *flags:
     {{ cargo }} {{ _test }} \
         --workspace --frozen {{ _features }} \
+        --exclude=kubert-examples \
         {{ if build-type == "release" { "--release" } else { "" } }} \
         {{ flags }}
 
@@ -169,6 +171,22 @@ test-cluster-deploy-watch-pods *flags: test-cluster-import-examples
 
 # Use the test cluster to run the examples (as is done in CI).
 integrate-examples: test-cluster-import-examples test-cluster-run-watch-pods test-cluster-create-ns test-cluster-deploy-watch-pods test-cluster-delete-ns
+
+build-test-lease *flags:
+    {{ cargo }} test --no-run \
+        --workspace --frozen {{ _features }} \
+        --package=kubert-examples --test=lease \
+        {{ if build-type == "release" { "--release" } else { "" } }} \
+        {{ flags }} \
+        {{ _fmt }}
+
+# Run all tests
+test-lease *flags: _test-cluster-exists
+    {{ cargo }} {{ _test }} \
+        --workspace --frozen {{ _features }} \
+        --package=kubert-examples --test=lease \
+        {{ if build-type == "release" { "--release" } else { "" } }} \
+        {{ flags }}
 
 # Display the git history minus dependabot updates
 history *paths='.':

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -36,6 +36,18 @@ index = [
     "tracing",
 ]
 initialized = ["futures-core", "futures-util", "pin-project-lite", "tokio/sync"]
+lease = [
+    "chrono",
+    "hyper",
+    "k8s-openapi",
+    "kube-client",
+    "kube-core",
+    "serde",
+    "serde_json",
+    "thiserror",
+    "tokio/sync",
+    "tracing",
+]
 log = ["thiserror", "tracing", "tracing-subscriber"]
 requeue = [
     "futures-core",
@@ -85,13 +97,12 @@ shutdown = [
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
-features = [
-    "k8s-openapi/v1_25",
-]
+features = ["k8s-openapi/v1_25"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
 drain = { version = "0.1.1", optional = true, default-features = false }
+chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
@@ -100,6 +111,7 @@ pin-project-lite = { version = "0.2", optional = true }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }
 tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.23.2", optional = true, default-features = false }
@@ -141,8 +153,9 @@ optional = true
 default-features = false
 features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"]
 
+# === Dev ===
+
 [dev-dependencies]
-kube = { version = "0.75", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
@@ -151,6 +164,11 @@ tracing-subscriber = { version = "0.3", features = ["ansi"] }
 version = "0.16"
 default-features = false
 features = ["v1_25"]
+
+[dev-dependencies.kube]
+version = "0.75"
+default-features = false
+features = ["client", "runtime", "native-tls"]
 
 [dev-dependencies.tokio]
 version = "1.18"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -156,6 +156,7 @@ features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"]
 # === Dev ===
 
 [dev-dependencies]
+kube = { version = "0.75", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
@@ -164,11 +165,6 @@ tracing-subscriber = { version = "0.3", features = ["ansi"] }
 version = "0.16"
 default-features = false
 features = ["v1_25"]
-
-[dev-dependencies.kube]
-version = "0.75"
-default-features = false
-features = ["client", "runtime", "native-tls"]
 
 [dev-dependencies.tokio]
 version = "1.18"

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -1,11 +1,11 @@
-//! A distributed cooperative lock implemntation for Kubernetes
+//! A distributed, advisory lock implementation for Kubernetes
 //!
 //! Applications that manage state in Kubernetes--for instance, those that
 //! update resource statuses, may need to coordinate access to that state so
 //! that only one replica is trying to update resources at a time.
 //!
-//! The module manages [`coordv1::Lease`] resources to ensure that only a single
-//! claimant owns the lease.
+//! [`LeaseManager`] interacts with a [`coordv1::Lease`] resource to ensure that
+//! only a single claimant owns the lease at a time.
 
 use k8s_openapi::{api::coordination::v1 as coordv1, apimachinery::pkg::apis::meta::v1 as metav1};
 use std::{borrow::Cow, sync::Arc};

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -7,7 +7,7 @@
 //! The module manages [`coordv1::Lease`] resources to ensure that only a single
 //! claimant owns the lease.
 
-use k8s_openapi::{api::coordination::v1 as coordv1, apimachinery::pkg::apis::meta::v1::MicroTime};
+use k8s_openapi::{api::coordination::v1 as coordv1, apimachinery::pkg::apis::meta::v1 as metav1};
 use std::sync::Arc;
 use tokio::time::Duration;
 
@@ -329,8 +329,8 @@ impl Lease {
                     "resourceVersion": meta.version,
                 },
                 "spec": {
-                    "acquireTime": MicroTime(now),
-                    "renewTime": MicroTime(now),
+                    "acquireTime": metav1::MicroTime(now),
+                    "renewTime": metav1::MicroTime(now),
                     "holderIdentity": claimant,
                     "leaseDurationSeconds": lease_duration.num_seconds(),
                     "leaseTransitions": meta.transitions + 1,
@@ -375,7 +375,7 @@ impl Lease {
                     "resourceVersion": meta.version,
                 },
                 "spec": {
-                    "renewTime": MicroTime(now),
+                    "renewTime": metav1::MicroTime(now),
                     "leaseDurationSeconds": lease_duration.num_seconds(),
                 },
             })))
@@ -445,7 +445,7 @@ impl Lease {
 
         let holder = or_unclaimed!(spec.holder_identity);
 
-        let MicroTime(renew_time) = or_unclaimed!(spec.renew_time);
+        let metav1::MicroTime(renew_time) = or_unclaimed!(spec.renew_time);
         let lease_duration =
             chrono::Duration::seconds(or_unclaimed!(spec.lease_duration_seconds).into());
         let expiry = renew_time + lease_duration;

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -231,7 +231,7 @@ impl LeaseManager {
     ///
     /// This is typically used during process shutdown so that another process
     /// can potentially claim the lease before the prior lease duration expires.
-    pub async fn abdicate(&self, claimant: &str) -> Result<bool, Error> {
+    pub async fn vacate(&self, claimant: &str) -> Result<bool, Error> {
         let mut state = self.state.lock().await;
         if let Some(claim) = state.claim.take() {
             if claim.is_current() {
@@ -270,7 +270,7 @@ impl LeaseManager {
     /// The state of the lease is published via the returned receiver.
     ///
     /// When all receivers are dropped, the task completes and the lease is
-    /// abdicated so that another process can claim it.
+    /// vacated so that another process can claim it.
     pub async fn spawn(
         self,
         claimant: impl ToString,
@@ -306,7 +306,7 @@ impl LeaseManager {
                 }
             }
 
-            self.abdicate(&claimant).await?;
+            self.vacate(&claimant).await?;
             Ok(())
         });
 

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -1,0 +1,464 @@
+//! A distributed cooperative lock implemntation for Kubernetes
+//!
+//! Applications that manage state in Kubernetes--for instance, those that
+//! update resource statuses, may need to coordinate access to that state so
+//! that only one replica is trying to update resources at a time.
+//!
+//! The module manages [`coordv1::Lease`] resources to ensure that only a single
+//! claimant owns the lease.
+
+use k8s_openapi::{api::coordination::v1 as coordv1, apimachinery::pkg::apis::meta::v1::MicroTime};
+use tokio::time::Duration;
+
+/// A Kubernetes `Lease`
+#[cfg_attr(docsrs, doc(cfg(feature = "lease")))]
+pub struct Lease {
+    api: Api,
+    name: String,
+    field_manager: String,
+    state: tokio::sync::Mutex<State>,
+}
+
+/// Configuration used when obtaining a lease.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "lease")))]
+pub struct ClaimParams {
+    /// The duration of the lease
+    pub lease_duration: Duration,
+
+    /// The amount of time before the lease expiration that the lease holder
+    /// should renew the lease
+    pub renew_grace_period: Duration,
+}
+
+/// Describes the state of a lease
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "lease")))]
+pub struct Claim {
+    /// The identity of the claim holder.
+    pub holder: String,
+
+    /// The time that the lease expires.
+    pub expiry: chrono::DateTime<chrono::Utc>,
+}
+
+/// Indicates an error interacting with the Lease API
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(docsrs, doc(cfg(feature = "lease")))]
+pub enum Error {
+    /// An error was received from the Kubernetes API
+    #[error("failed to get lease: {0}")]
+    Api(#[from] kube_client::Error),
+
+    /// Lease resource does not have a resourceVersion
+    #[error("lease does not have a resource version")]
+    MissingResourceVersion,
+
+    /// Lease resource does not have a spec
+    #[error("lease does not have a spec")]
+    MissingSpec,
+}
+
+#[derive(Clone, Debug)]
+struct State {
+    meta: Meta,
+    claim: Option<Claim>,
+}
+
+#[derive(Clone, Debug)]
+struct Meta {
+    version: String,
+    transitions: u16,
+}
+
+type Api = kube_client::Api<coordv1::Lease>;
+
+// === impl ClaimpParams ===
+
+impl Default for ClaimParams {
+    fn default() -> Self {
+        Self {
+            lease_duration: Duration::from_secs(30),
+            renew_grace_period: Duration::from_secs(1),
+        }
+    }
+}
+
+// === impl Claim ===
+
+impl Claim {
+    /// Returns true iff the claim is still valid according to the system clock
+    #[inline]
+    pub fn is_current(&self) -> bool {
+        chrono::Utc::now() < self.expiry
+    }
+
+    /// Returns true iff the claim is still valid
+    #[inline]
+    pub fn is_current_for(&self, claimant: &str) -> bool {
+        self.holder == claimant && self.is_current()
+    }
+
+    /// Waits for the claim to expire
+    pub async fn expire(&self) {
+        self.expire_with_grace(Duration::ZERO).await;
+    }
+
+    /// Waits until there is a grace period remaining before the claim expires
+    pub async fn expire_with_grace(&self, grace: Duration) {
+        if let Ok(remaining) = (self.expiry - chrono::Utc::now()).to_std() {
+            let sleep = remaining.saturating_sub(grace);
+            if !sleep.is_zero() {
+                tokio::time::sleep(sleep).await;
+            }
+        }
+    }
+}
+
+// === impl Lease ===
+
+impl Lease {
+    /// Initialize a lease's state from the Kubernetes API.
+    ///
+    /// The lease resource must already have been created, or a 404 error will
+    /// be returned.
+    pub async fn init(
+        api: Api,
+        name: impl ToString,
+        field_manager: impl ToString,
+    ) -> Result<Self, Error> {
+        let name = name.to_string();
+        let state = Self::get(api.clone(), &*name).await?;
+        Ok(Self {
+            api,
+            name,
+            field_manager: field_manager.to_string(),
+            state: tokio::sync::Mutex::new(state),
+        })
+    }
+
+    /// Return the state of the claim without updating it from the API.
+    pub async fn claimed(&self) -> Option<Claim> {
+        self.state.lock().await.claim.clone()
+    }
+
+    /// Update the state of the claim from the API.
+    pub async fn sync(&self) -> Result<Option<Claim>, Error> {
+        let mut state = self.state.lock().await;
+        *state = Self::get(self.api.clone(), &self.name).await?;
+        Ok(state.claim.clone())
+    }
+
+    /// Ensures that the lease, if it exists, is claimed.
+    ///
+    /// If these is not currently held, it is claimed by the provided identity.
+    /// If it is currently held by the provided claimant, it is renewed if it is
+    /// within the renew grace period.
+    pub async fn ensure_claimed(
+        &self,
+        claimant: &str,
+        params: &ClaimParams,
+    ) -> Result<Claim, Error> {
+        let mut state = self.state.lock().await;
+        loop {
+            if let Some(claim) = state.claim.as_ref() {
+                // If the claim is held by the provided identity,  see
+                if claim.holder == claimant {
+                    let renew_at = claim.expiry
+                        - chrono::Duration::from_std(params.renew_grace_period)
+                            .unwrap_or_else(|_| chrono::Duration::zero());
+                    if chrono::Utc::now() < renew_at {
+                        return Ok(claim.clone());
+                    }
+
+                    let (claim, meta) = match self.renew(&state.meta, claimant, params).await {
+                        Ok(renew) => renew,
+                        Err(e) if Self::is_conflict(&e) => {
+                            // Another process updated the claim's resource version, so
+                            // re-sync the state and try again.
+                            *state = Self::get(self.api.clone(), &*self.name).await?;
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    };
+                    *state = State {
+                        claim: Some(claim.clone()),
+                        meta,
+                    };
+                    return Ok(claim);
+                }
+
+                // The claim is held by another claimant, return it.
+                if claim.is_current() {
+                    return Ok(claim.clone());
+                }
+            }
+
+            // There's no current claim, so try to acquire it.
+            let (claim, meta) = match self.acquire(&state.meta, claimant, params).await {
+                Ok(acquire) => acquire,
+                Err(e) if Self::is_conflict(&e) => {
+                    // Another process updated the claim's resource version, so
+                    // re-sync the state and try again.
+                    *state = Self::get(self.api.clone(), &*self.name).await?;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+            *state = State {
+                claim: Some(claim.clone()),
+                meta,
+            };
+            return Ok(claim);
+        }
+    }
+
+    /// Clear out the state of the lease if the claim is currently held by the
+    /// provided identity.
+    ///
+    /// This is typically used during process shutdown so that another process
+    /// can potentially claim the lease before the prior lease duration expires.
+    pub async fn abdicate(&self, identity: &str) -> Result<bool, Error> {
+        let mut state = self.state.lock().await;
+        if let Some(claim) = state.claim.take() {
+            if claim.is_current_for(identity) {
+                self.patch(&kube_client::api::Patch::Strategic(serde_json::json!({
+                    "apiVersion": "coordination.k8s.io/v1",
+                    "kind": "Lease",
+                    "metadata": {
+                        "resourceVersion": state.meta.version,
+                    },
+                    "spec": {
+                        "acquireTime": Option::<()>::None,
+                        "renewTime": Option::<()>::None,
+                        "holderIdentity": Option::<()>::None,
+                        "leaseDurationSeconds": Option::<()>::None,
+                        // leaseTransitions is preserved by strategic patch
+                    },
+                })))
+                .await?;
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Spawn a task that ensures the lease is claimed.
+    ///
+    /// When the lease becomes unclaimed, the task attempts to claim the lease
+    /// as _claimant_ and maintains the lease until the task completes or the
+    /// lease is claimed by another process.
+    ///
+    /// The state of the lease is published via the returned receiver.
+    ///
+    /// When all receivers are dropped, the task completes and the lease is
+    /// abdicated so that another process can claim it.
+    pub async fn spawn_claimant(
+        self,
+        claimant: String,
+        params: ClaimParams,
+    ) -> Result<
+        (
+            tokio::sync::watch::Receiver<Claim>,
+            tokio::task::JoinHandle<Result<(), Error>>,
+        ),
+        Error,
+    > {
+        let mut claim = self.ensure_claimed(&claimant, &params).await?;
+        let (tx, rx) = tokio::sync::watch::channel(claim.clone());
+
+        let task = tokio::spawn(async move {
+            loop {
+                // The claimant has the privilege of renewing the lease before
+                // the claim expires.
+                let grace = if claim.holder == claimant {
+                    params.renew_grace_period
+                } else {
+                    Duration::ZERO
+                };
+
+                // Wait for the current claim to expire. If all receivers are
+                // dropped while we're waiting, the task terminates.
+                tokio::select! {
+                    biased;
+                    _ = tx.closed() => break,
+                    _ = claim.expire_with_grace(grace) => {}
+                }
+
+                // Update the claim and broadcast it to all receivers.
+                claim = self.ensure_claimed(&claimant, &params).await?;
+                if tx.send(claim.clone()).is_err() {
+                    // All receivers have been dropped.
+                    break;
+                }
+            }
+
+            self.abdicate(&claimant).await?;
+            Ok(())
+        });
+
+        Ok((rx, task))
+    }
+
+    /// Acquire the lease (i.e. assuming the claimant IS NOT the current holder
+    /// of the lease).
+    ///
+    /// A server-side apply is used to update the resource. If another writer
+    /// has updated the resource since the last read, this write fails with a
+    /// conflict.
+    async fn acquire(
+        &self,
+        meta: &Meta,
+        claimant: &str,
+        params: &ClaimParams,
+    ) -> Result<(Claim, Meta), Error> {
+        let lease_duration = chrono::Duration::from_std(params.lease_duration)
+            .unwrap_or_else(|_| chrono::Duration::max_value());
+        let now = chrono::Utc::now();
+        let lease = self
+            .patch(&kube_client::api::Patch::Apply(serde_json::json!({
+                "apiVersion": "coordination.k8s.io/v1",
+                "kind": "Lease",
+                "metadata": {
+                    "resourceVersion": meta.version,
+                },
+                "spec": {
+                    "acquireTime": MicroTime(now),
+                    "renewTime": MicroTime(now),
+                    "holderIdentity": claimant,
+                    "leaseDurationSeconds": lease_duration.num_seconds(),
+                    "leaseTransitions": meta.transitions + 1,
+                },
+            })))
+            .await?;
+
+        let claim = Claim {
+            holder: claimant.to_string(),
+            expiry: now + lease_duration,
+        };
+        let meta = Meta {
+            version: lease
+                .metadata
+                .resource_version
+                .ok_or(Error::MissingResourceVersion)?,
+            transitions: meta.transitions + 1,
+        };
+        Ok((claim, meta))
+    }
+
+    /// Renew the lease (i.e. assuming the claimant IS the current holder of the
+    /// lease).
+    ///
+    /// A strategic merge is used so that only the `renewTime` field is updated
+    /// in most cases. The `leaseDurationSeconds` fields may also be updated if
+    /// the caller passed an updated value.
+    async fn renew(
+        &self,
+        meta: &Meta,
+        claimant: &str,
+        params: &ClaimParams,
+    ) -> Result<(Claim, Meta), Error> {
+        let lease_duration = chrono::Duration::from_std(params.lease_duration)
+            .unwrap_or_else(|_| chrono::Duration::max_value());
+        let now = chrono::Utc::now();
+        let lease = self
+            .patch(&kube_client::api::Patch::Strategic(serde_json::json!({
+                "apiVersion": "coordination.k8s.io/v1",
+                "kind": "Lease",
+                "metadata": {
+                    "resourceVersion": meta.version,
+                },
+                "spec": {
+                    "renewTime": MicroTime(now),
+                    "leaseDurationSeconds": lease_duration.num_seconds(),
+                },
+            })))
+            .await?;
+
+        let claim = Claim {
+            holder: claimant.to_string(),
+            expiry: now + lease_duration,
+        };
+        let meta = Meta {
+            version: lease
+                .metadata
+                .resource_version
+                .ok_or(Error::MissingResourceVersion)?,
+            transitions: meta.transitions,
+        };
+        Ok((claim, meta))
+    }
+
+    async fn patch<P>(
+        &self,
+        patch: &kube_client::api::Patch<P>,
+    ) -> Result<coordv1::Lease, kube_client::Error>
+    where
+        P: serde::Serialize + std::fmt::Debug,
+    {
+        tracing::debug!(?patch);
+        let params = kube_client::api::PatchParams {
+            field_manager: Some(self.field_manager.clone()),
+            // Force conflict resolution when using Server-side Apply (i.e., to
+            // acquire a lease). This is the recommended behavior for
+            // controllers.
+            force: matches!(patch, kube_client::api::Patch::Apply(_)),
+            ..Default::default()
+        };
+        self.api.patch(&*self.name, &params, patch).await
+    }
+
+    async fn get(api: Api, name: &str) -> Result<State, Error> {
+        let lease = api.get(name).await?;
+
+        let spec = match lease.spec {
+            Some(spec) => spec,
+            None => return Err(Error::MissingSpec),
+        };
+
+        let version = lease
+            .metadata
+            .resource_version
+            .ok_or(Error::MissingResourceVersion)?;
+        let transitions = spec.lease_transitions.unwrap_or(0).try_into().unwrap_or(0);
+        let meta = Meta {
+            version,
+            transitions,
+        };
+
+        macro_rules! or_unclaimed {
+            ($e:expr) => {
+                match $e {
+                    Some(e) => e,
+                    None => {
+                        return Ok(State { meta, claim: None });
+                    }
+                }
+            };
+        }
+
+        let holder = or_unclaimed!(spec.holder_identity);
+
+        let MicroTime(renew_time) = or_unclaimed!(spec.renew_time);
+        let lease_duration =
+            chrono::Duration::seconds(or_unclaimed!(spec.lease_duration_seconds).into());
+        let expiry = renew_time + lease_duration;
+        if expiry <= chrono::Utc::now() {
+            return Ok(State { meta, claim: None });
+        }
+
+        Ok(State {
+            meta,
+            claim: Some(Claim { holder, expiry }),
+        })
+    }
+
+    fn is_conflict(err: &Error) -> bool {
+        matches!(
+            err,
+            Error::Api(kube_client::Error::Api(kube_core::ErrorResponse { code, .. }))
+                if hyper::StatusCode::from_u16(*code).ok() == Some(hyper::StatusCode::CONFLICT)
+        )
+    }
+}

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::client::ClientArgs;
 pub use self::initialized::Initialized;
 
 #[cfg(all(feature = "lease"))]
-pub use self::lease::Lease;
+pub use self::lease::LeaseManager;
 
 #[cfg(all(feature = "log"))]
 pub use self::log::{LogFilter, LogFormat, LogInitError};

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -26,6 +26,10 @@ pub mod index;
 #[cfg_attr(docsrs, doc(cfg(feature = "initialized")))]
 pub mod initialized;
 
+#[cfg(feature = "lease")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lease")))]
+pub mod lease;
+
 #[cfg(feature = "log")]
 #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
 pub mod log;
@@ -54,6 +58,9 @@ pub use self::client::ClientArgs;
 
 #[cfg(all(feature = "initialized"))]
 pub use self::initialized::Initialized;
+
+#[cfg(all(feature = "lease"))]
+pub use self::lease::Lease;
 
 #[cfg(all(feature = "log"))]
 pub use self::log::{LogFilter, LogFormat, LogInitError};


### PR DESCRIPTION
Applications that manage state in Kubernetes--for instance, those that update resource statuses--may need to coordinate access to that state so that only one replica is trying to update resources at a time.

The `lease` module manages coordination.k8s.io/v1 Lease resources to ensure that only a single claimant owns the lease.