### PR TITLE
[Prototype] Add prometheus metrics endpoint to admin server

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -15,6 +15,8 @@ admin = [
     "hyper/http1",
     "hyper/runtime",
     "hyper/server",
+    "metrics-exporter-prometheus",
+    "metrics-process",
     "tokio/sync",
     "tracing",
 ]
@@ -108,6 +110,8 @@ futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
+metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false}
+metrics-process = { version = "1.0.4", optional = true}
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -39,6 +39,7 @@ pub struct Builder {
 
 /// Supports spawning an admin server
 #[cfg_attr(docsrs, doc(cfg(feature = "admin")))]
+#[derive(Debug)]
 pub struct Bound {
     addr: SocketAddr,
     ready: Readiness,
@@ -52,6 +53,7 @@ pub struct Readiness(Arc<AtomicBool>);
 
 /// A handle to a running admin server
 #[cfg_attr(docsrs, doc(cfg(feature = "admin")))]
+#[derive(Debug)]
 pub struct Server {
     addr: SocketAddr,
     ready: Readiness,

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -108,7 +108,11 @@ impl Builder {
 
     /// Binds the admin server without accepting connections
     pub fn bind(self) -> Result<Bound> {
-        let Self { addr, ready, prometheus } = self;
+        let Self {
+            addr,
+            ready,
+            prometheus,
+        } = self;
 
         let server = hyper::server::Server::try_bind(&addr)?
             // Allow weird clients (like netcat).
@@ -141,8 +145,8 @@ impl Bound {
     /// Binds and runs the server on a background task, returning a handle
     pub fn spawn(self) -> Server {
         let ready = self.ready.clone();
-        let metrics = self.prometheus
-
+        let metrics = self
+            .prometheus
             .install_recorder()
             .expect("failed to install Prometheus recorder");
         let process = Collector::default();

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -141,8 +141,6 @@ impl Bound {
         process.describe();
 
         let server = {
-            let metrics = metrics.clone();
-            let process = process.clone();
             self.server
                 .serve(hyper::service::make_service_fn(move |_conn| {
                     let ready = ready.clone();


### PR DESCRIPTION
This change uses the `metrics-exporter-prometheus` crate to add a `/metrics` endpoint to the kubert admin server which serves Prometheus metrics.  These metrics are collected through the `metrics` ecosystem and any metrics registered through the `metrics` crate macros will be exposed on this endpoint.

Additionally, we use the `metrics-process` crate to register process level metrics.

Sample output from the /metrics endpoint:

```
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1048576

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 358113280

# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 0

# HELP process_threads Numberof OS threads in the process.
# TYPE process_threads gauge
process_threads 5

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1671068715

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 65015808

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 25

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total gauge
process_cpu_seconds_total 0.48
```