### PR TITLE
admin: make 405 responses standards-compliant

### DIFF
--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -210,6 +210,7 @@ fn handle_live(req: Request<Body>) -> Response<Body> {
             .unwrap(),
         _ => Response::builder()
             .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
+            .header(hyper::header::ALLOW, "GET, HEAD")
             .body(Body::default())
             .unwrap(),
     }
@@ -234,6 +235,7 @@ fn handle_ready(Readiness(ready): &Readiness, req: Request<Body>) -> Response<Bo
         }
         _ => Response::builder()
             .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
+            .header(hyper::header::ALLOW, "GET, HEAD")
             .body(Body::default())
             .unwrap(),
     }


### PR DESCRIPTION
This is probably not actually a big deal, but according to [RFC 9110], when sending a 405 Method Not Allowed status:

> The origin server MUST generate an [Allow] header field in a 405
> response containing a list of the target resource's currently
> supported methods.

This branch updates the admin server's `/live` and `/ready` endpoints so that when an unsupported request method is received, the returned 405 response includes an `Allow` header, making the server compliant with the RFC.

[RFC 9110]: https://httpwg.org/specs/rfc9110.html#status.405
[Allow]: https://httpwg.org/specs/rfc9110.html#field.allow