### PR TITLE
add Prometheus metrics endpoint

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -40,12 +40,14 @@ jobs:
       matrix:
         feature:
           - admin
+          - admin,metrics
           - client
           - errors
           - index
           - initialized
           - lease
           - log
+          - metrics
           - requeue
           - runtime
           - server

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,7 @@ ignore = []
 
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT"]
+allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT", "Zlib"]
 deny = []
 copyleft = "deny"
 allow-osi-fsf-free = "neither"

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,7 @@ ignore = []
 
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT", "Zlib"]
+allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT"]
 deny = []
 copyleft = "deny"
 allow-osi-fsf-free = "neither"
@@ -32,6 +32,7 @@ exceptions = [
         "Apache-2.0",
         "Unicode-DFS-2016",
     ], name = "unicode-ident" },
+    { allow = ["Zlib"], name = "adler32" },
 ]
 
 [[licenses.clarify]]
@@ -45,14 +46,22 @@ multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
 deny = []
-skip-tree = []
 skip = [
+    # `rustls-pemfile` and `k8s-openapi` depend on versions of `base64` that
+    # have diverged significantly.
+    { name = "base64" },
+]
+skip-tree = [
     { name = "windows-sys" },
     { name = "windows_aarch64_msvc" },
     { name = "windows_i686_gnu" },
     { name = "windows_i686_msvc" },
     { name = "windows_x86_64_gnu" },
     { name = "windows_x86_64_msvc" },
+    # `metrics` and `kube-runtime` have conflicting versions of `ahash` and
+    # `wasi`.
+    # TODO(eliza): remove this skip when the conflicts are resolved.
+    { name = "metrics" },
 ]
 
 [sources]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -15,6 +15,8 @@ admin = [
     "hyper/http1",
     "hyper/runtime",
     "hyper/server",
+    "metrics-exporter-prometheus",
+    "metrics-process",
     "tokio/sync",
     "tracing",
 ]
@@ -108,6 +110,8 @@ futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
+metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false}
+metrics-process = { version = "1.0.4", optional = true}
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 
 [features]
 admin = [
+    "ahash",
     "futures-util",
     "hyper/http1",
     "hyper/runtime",

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -54,6 +54,7 @@ metrics = [
     "metrics-exporter-prometheus",
     "metrics-process",
     "metrics-util",
+    "ipnet",
 ]
 requeue = [
     "futures-core",
@@ -113,6 +114,7 @@ chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
+ipnet = { version = "2", optional = true }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -54,7 +54,6 @@ metrics = [
     "metrics-exporter-prometheus",
     "metrics-process",
     "metrics-util",
-    "ipnet",
 ]
 requeue = [
     "futures-core",
@@ -114,7 +113,6 @@ chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
-ipnet = { version = "2", optional = true }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -49,12 +49,7 @@ lease = [
     "tracing",
 ]
 log = ["thiserror", "tracing", "tracing-subscriber"]
-metrics = [
-    "deflate",
-    "metrics-exporter-prometheus",
-    "metrics-process",
-    "metrics-util",
-]
+metrics = ["deflate", "metrics-exporter-prometheus", "metrics-process"]
 requeue = [
     "futures-core",
     "tokio/macros",
@@ -115,9 +110,8 @@ futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
-metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false }
+metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false}
 metrics-process = { version = "1.0.4", optional = true}
-metrics-util = { version = "0.14.0", optional = true, default-features = false }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -15,8 +15,6 @@ admin = [
     "hyper/http1",
     "hyper/runtime",
     "hyper/server",
-    "metrics-exporter-prometheus",
-    "metrics-process",
     "tokio/sync",
     "tracing",
 ]
@@ -51,6 +49,7 @@ lease = [
     "tracing",
 ]
 log = ["thiserror", "tracing", "tracing-subscriber"]
+metrics = ["metrics-exporter-prometheus", "metrics-process"]
 requeue = [
     "futures-core",
     "tokio/macros",

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -49,7 +49,12 @@ lease = [
     "tracing",
 ]
 log = ["thiserror", "tracing", "tracing-subscriber"]
-metrics = ["deflate", "metrics-exporter-prometheus", "metrics-process"]
+metrics = [
+    "deflate",
+    "metrics-exporter-prometheus",
+    "metrics-process",
+    "metrics-util",
+]
 requeue = [
     "futures-core",
     "tokio/macros",
@@ -110,8 +115,9 @@ futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
-metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false}
+metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false }
 metrics-process = { version = "1.0.4", optional = true}
+metrics-util = { version = "0.14.0", optional = true, default-features = false }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -49,7 +49,7 @@ lease = [
     "tracing",
 ]
 log = ["thiserror", "tracing", "tracing-subscriber"]
-metrics = ["metrics-exporter-prometheus", "metrics-process"]
+metrics = ["deflate", "metrics-exporter-prometheus", "metrics-process"]
 requeue = [
     "futures-core",
     "tokio/macros",
@@ -102,6 +102,7 @@ features = ["k8s-openapi/v1_25"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
+deflate = { version = "1", optional = true, default-features = false, features = ["gzip"] }
 drain = { version = "0.1.1", optional = true, default-features = false }
 chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -20,7 +20,8 @@ pub type Result<T> = hyper::Result<T>;
 pub type Error = hyper::Error;
 
 #[cfg(feature = "metrics")]
-mod metrics;
+#[cfg_attr(docsrs, doc(cfg(all(feature = "admin", feature = "metrics"))))]
+pub mod metrics;
 
 /// Command-line arguments used to configure an admin server
 #[derive(Clone, Debug)]
@@ -110,23 +111,12 @@ impl Builder {
         self.ready.set(true);
     }
 
-    /// Use the given `PrometheusBuilder` for the metrics endpoint.
+    /// Use the given [`PrometheusBuilder`] for the metrics endpoint.
     ///
     /// This method is only available if the "metrics" feature is enabled.
-    ///
-    /// **Note**: Builder methods that configure `metrics-exporter-prometheus`'s
-    /// built-in HTTP listener, such as
-    /// [`PrometheusBuilder::with_http_listener`][http] and
-    /// [`PrometheusBuilder::add_allowed_address`][allowed] will not have an
-    /// effect on the admin server's `/metrics` endpoint, since the HTTP
-    /// server is managed by `kubert` rather than by `metrics-exporter-prometheus`.
-    ///
-    /// [http]: https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.with_http_listener
-    /// [allowed]: https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.add_allowed_address
-    // TODO(eliza): we may want to implement our own versions of these methods...
     #[cfg(feature = "metrics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-    pub fn set_prometheus(&mut self, prometheus: metrics::PrometheusBuilder) {
+    pub fn with_prometheus(&mut self, prometheus: metrics::PrometheusBuilder) {
         self.prometheus = prometheus;
     }
 

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -39,6 +39,7 @@ pub struct Builder {
 
 /// Supports spawning an admin server
 #[cfg_attr(docsrs, doc(cfg(feature = "admin")))]
+#[derive(Debug)]
 pub struct Bound {
     addr: SocketAddr,
     ready: Readiness,
@@ -52,6 +53,7 @@ pub struct Readiness(Arc<AtomicBool>);
 
 /// A handle to a running admin server
 #[cfg_attr(docsrs, doc(cfg(feature = "admin")))]
+#[derive(Debug)]
 pub struct Server {
     addr: SocketAddr,
     ready: Readiness,

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -108,7 +108,11 @@ impl Builder {
 
     /// Binds the admin server without accepting connections
     pub fn bind(self) -> Result<Bound> {
-        let Self { addr, ready, prometheus } = self;
+        let Self {
+            addr,
+            ready,
+            prometheus,
+        } = self;
 
         let server = hyper::server::Server::try_bind(&addr)?
             // Allow weird clients (like netcat).
@@ -141,8 +145,8 @@ impl Bound {
     /// Binds and runs the server on a background task, returning a handle
     pub fn spawn(self) -> Server {
         let ready = self.ready.clone();
-        let metrics = self.prometheus
-
+        let metrics = self
+            .prometheus
             .install_recorder()
             .expect("failed to install Prometheus recorder");
         let process = Collector::default();

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -113,6 +113,17 @@ impl Builder {
     /// Use the given `PrometheusBuilder` for the metrics endpoint.
     ///
     /// This method is only available if the "metrics" feature is enabled.
+    ///
+    /// **Note**: Builder methods that configure `metrics-exporter-prometheus`'s
+    /// built-in HTTP listener, such as
+    /// [`PrometheusBuilder::with_http_listener`][http] and
+    /// [`PrometheusBuilder::add_allowed_address`][allowed] will not have an
+    /// effect on the admin server's `/metrics` endpoint, since the HTTP
+    /// server is managed by `kubert` rather than by `metrics-exporter-prometheus`.
+    ///
+    /// [http]: https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.with_http_listener
+    /// [allowed]: https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.add_allowed_address
+    // TODO(eliza): we may want to implement our own versions of these methods...
     #[cfg(feature = "metrics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
     pub fn set_prometheus(&mut self, prometheus: metrics::PrometheusBuilder) {

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -169,14 +169,10 @@ impl Bound {
         let prometheus = metrics::Prometheus::new(self.prometheus);
 
         let server = {
-            self.server.serve(hyper::service::make_service_fn(
-                move |conn: &hyper::server::conn::AddrStream| {
-                    let ready = ready.clone();
-
-                    #[cfg(feature = "metrics")]
+            self.server
+                .serve(hyper::service::make_service_fn(move |conn| {
                     let remote_ip = conn.remote_addr().ip();
-                    #[cfg(not(feature = "metrics"))]
-                    let _ = conn;
+                    let ready = ready.clone();
 
                     #[cfg(feature = "metrics")]
                     let prometheus = prometheus.clone();
@@ -195,8 +191,7 @@ impl Bound {
                             ),
                         },
                     ))
-                },
-            ))
+                }))
         };
 
         let task = tokio::spawn(

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -168,7 +168,7 @@ impl fmt::Debug for Builder {
         // `fmt::Debug`, but when the "metrics" feature is enabled, at least
         // indicate that it's there.
         #[cfg(feature = "metrics")]
-        d.field("prometheus", &format_args!("PrometheusBuilder { ... }"));
+        d.field("prometheus", &format_args!("PrometheusBuilder {{ ... }}"));
 
         d.finish()
     }

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -3,7 +3,6 @@ use futures_util::future;
 use hyper::{Body, Request, Response};
 
 use std::{
-    fmt,
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -35,6 +34,7 @@ pub struct AdminArgs {
 
 /// Supports configuring an admin server
 #[cfg_attr(docsrs, doc(cfg(feature = "admin")))]
+#[derive(Debug)]
 pub struct Builder {
     addr: SocketAddr,
     ready: Readiness,
@@ -149,21 +149,6 @@ impl Builder {
     }
 }
 
-impl fmt::Debug for Builder {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut d = f.debug_struct("Builder");
-        d.field("addr", &self.addr).field("ready", &self.ready);
-
-        // The `PrometheusBuilder` type does not actually implement
-        // `fmt::Debug`, but when the "metrics" feature is enabled, at least
-        // indicate that it's there.
-        #[cfg(feature = "metrics")]
-        d.field("prometheus", &format_args!("PrometheusBuilder {{ ... }}"));
-
-        d.finish()
-    }
-}
-
 // === impl Bound ===
 
 impl Bound {
@@ -185,7 +170,8 @@ impl Bound {
 
         let server = {
             self.server
-                .serve(hyper::service::make_service_fn(move |_conn| {
+                .serve(hyper::service::make_service_fn(move |conn| {
+                    let remote_ip = conn.remote_addr().ip();
                     let ready = ready.clone();
 
                     #[cfg(feature = "metrics")]
@@ -196,7 +182,7 @@ impl Bound {
                             "/live" => future::ok(handle_live(req)),
                             "/ready" => future::ok(handle_ready(&ready, req)),
                             #[cfg(feature = "metrics")]
-                            "/metrics" => future::ok(prometheus.handle_metrics(req)),
+                            "/metrics" => future::ok(prometheus.handle_metrics(remote_ip, req)),
                             _ => future::ok::<_, hyper::Error>(
                                 Response::builder()
                                     .status(hyper::StatusCode::NOT_FOUND)

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -3,6 +3,7 @@ use futures_util::future;
 use hyper::{Body, Request, Response};
 
 use std::{
+    fmt,
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -146,6 +147,23 @@ impl Builder {
         })
     }
 }
+
+impl fmt::Debug for Builder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("Builder");
+        d.field("addr", &self.addr).field("ready", &self.ready);
+
+        // The `PrometheusBuilder` type does not actually implement
+        // `fmt::Debug`, but when the "metrics" feature is enabled, at least
+        // indicate that it's there.
+        #[cfg(feature = "metrics")]
+        d.field("prometheus", &format_args!("PrometheusBuilder { ... }"));
+
+        d.finish()
+    }
+}
+
+// === impl Bound ===
 
 impl Bound {
     /// Returns a readiness handle

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -20,8 +20,7 @@ pub type Result<T> = hyper::Result<T>;
 pub type Error = hyper::Error;
 
 #[cfg(feature = "metrics")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "admin", feature = "metrics"))))]
-pub mod metrics;
+mod metrics;
 
 /// Command-line arguments used to configure an admin server
 #[derive(Clone, Debug)]
@@ -111,12 +110,23 @@ impl Builder {
         self.ready.set(true);
     }
 
-    /// Use the given [`PrometheusBuilder`] for the metrics endpoint.
+    /// Use the given `PrometheusBuilder` for the metrics endpoint.
     ///
     /// This method is only available if the "metrics" feature is enabled.
+    ///
+    /// **Note**: Builder methods that configure `metrics-exporter-prometheus`'s
+    /// built-in HTTP listener, such as
+    /// [`PrometheusBuilder::with_http_listener`][http] and
+    /// [`PrometheusBuilder::add_allowed_address`][allowed] will not have an
+    /// effect on the admin server's `/metrics` endpoint, since the HTTP
+    /// server is managed by `kubert` rather than by `metrics-exporter-prometheus`.
+    ///
+    /// [http]: https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.with_http_listener
+    /// [allowed]: https://docs.rs/metrics-exporter-prometheus/latest/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.add_allowed_address
+    // TODO(eliza): we may want to implement our own versions of these methods...
     #[cfg(feature = "metrics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-    pub fn with_prometheus(&mut self, prometheus: metrics::PrometheusBuilder) {
+    pub fn set_prometheus(&mut self, prometheus: metrics::PrometheusBuilder) {
         self.prometheus = prometheus;
     }
 

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -1,7 +1,6 @@
 //! Admin server utilities.
 use futures_util::future;
 use hyper::{Body, Request, Response};
-
 use std::{
     collections::HashMap,
     fmt,

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -141,8 +141,6 @@ impl Bound {
         process.describe();
 
         let server = {
-            let metrics = metrics.clone();
-            let process = process.clone();
             self.server
                 .serve(hyper::service::make_service_fn(move |_conn| {
                     let ready = ready.clone();

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -1,8 +1,8 @@
 //! Admin server utilities.
+use ahash::AHashMap;
 use futures_util::future;
 use hyper::{Body, Request, Response};
 use std::{
-    collections::HashMap,
     fmt,
     net::SocketAddr,
     sync::{
@@ -40,7 +40,7 @@ pub struct AdminArgs {
 pub struct Builder {
     addr: SocketAddr,
     ready: Readiness,
-    routes: HashMap<String, HandlerFn>,
+    routes: AHashMap<String, HandlerFn>,
 }
 
 /// Supports spawning an admin server
@@ -49,7 +49,7 @@ pub struct Bound {
     addr: SocketAddr,
     ready: Readiness,
     server: hyper::server::Builder<hyper::server::conn::AddrIncoming>,
-    routes: HashMap<String, HandlerFn>,
+    routes: AHashMap<String, HandlerFn>,
 }
 
 /// Controls how the admin server advertises readiness

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,143 +1,16 @@
 use super::*;
 
 use hyper::header;
-pub use metrics_exporter_prometheus::{BuildError, Matcher};
-use metrics_exporter_prometheus::{PrometheusBuilder as InnerBuilder, PrometheusHandle};
+pub(super) use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::PrometheusHandle;
 use metrics_process::Collector;
-pub use metrics_util::MetricKindMask;
 
-use std::{fmt, time::Duration};
-
-/// Configures an admin server's [Prometheus] metrics endpoint.
-///
-/// This builder is passed to the [`admin::Builder::with_prometheus`] method to
-/// enable the metrics endpoint.
-///
-/// [Prometheus]: https://prometheus.io/
-/// [`admin::Builder::with_prometheus`]: super::Builder::with_prometheus
-#[derive(Default)]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "admin", feature = "metrics"))))]
-pub struct PrometheusBuilder {
-    inner: InnerBuilder,
-}
+use std::fmt;
 
 #[derive(Clone)]
 pub(super) struct Prometheus {
     metrics: PrometheusHandle,
     process: Collector,
-}
-
-// === impl PrometheusBuilder ===
-
-impl PrometheusBuilder {
-    /// Creates a new [`PrometheusBuilder`].
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            inner: InnerBuilder::new(),
-        }
-    }
-
-    /// Sets the quantiles to use when rendering histograms.
-    ///
-    /// Quantiles represent a scale of 0 to 1, where percentiles represent a scale of 1 to 100, so
-    /// a quantile of 0.99 is the 99th percentile, and a quantile of 0.99 is the 99.9th percentile.
-    ///
-    /// Defaults to a hard-coded set of quantiles: 0.0, 0.5, 0.9, 0.95, 0.99, 0.999, and 1.0. This means
-    /// that all histograms will be exposed as Prometheus summaries.
-    ///
-    /// If buckets are set (via [`set_buckets`][Self::set_buckets] or
-    /// [`set_buckets_for_metric`][Self::set_buckets_for_metric]) then all histograms will be exposed
-    /// as summaries instead.
-    ///
-    /// ## Errors
-    ///
-    /// If `quantiles` is empty, an error variant will be thrown.
-    pub fn set_quantiles(self, quantiles: &[f64]) -> Result<Self, BuildError> {
-        self.try_map(|inner| inner.set_quantiles(quantiles))
-    }
-
-    /// Sets the buckets to use when rendering histograms.
-    ///
-    /// Buckets values represent the higher bound of each buckets.  If buckets are set, then all
-    /// histograms will be rendered as true Prometheus histograms, instead of summaries.
-    ///
-    /// ## Errors
-    ///
-    /// If `values` is empty, an error variant will be thrown.
-    pub fn set_buckets(self, values: &[f64]) -> Result<Self, BuildError> {
-        self.try_map(|inner| inner.set_buckets(values))
-    }
-
-    /// Sets the bucket for a specific pattern.
-    ///
-    /// The match pattern can be a full match (equality), prefix match, or suffix match.  The
-    /// matchers are applied in that order if two or more matchers would apply to a single metric.
-    /// That is to say, if a full match and a prefix match applied to a metric, the full match would
-    /// win, and if a prefix match and a suffix match applied to a metric, the prefix match would win.
-    ///
-    /// Buckets values represent the higher bound of each buckets.  If buckets are set, then any
-    /// histograms that match will be rendered as true Prometheus histograms, instead of summaries.
-    ///
-    /// This option changes the observer's output of histogram-type metric into summaries.
-    /// It only affects matching metrics if [`set_buckets`][Self::set_buckets] was not used.
-    ///
-    /// ## Errors
-    ///
-    /// If `values` is empty, an error variant will be thrown.
-    pub fn set_buckets_for_metric(
-        self,
-        matcher: Matcher,
-        values: &[f64],
-    ) -> Result<Self, BuildError> {
-        self.try_map(|inner| inner.set_buckets_for_metric(matcher, values))
-    }
-
-    /// Sets the idle timeout for metrics.
-    ///
-    /// If a metric hasn't been updated within this timeout, it will be removed from the registry
-    /// and in turn removed from the normal scrape output until the metric is emitted again.  This
-    /// behavior is driven by requests to generate rendered output, and so metrics will not be
-    /// removed unless a request has been made recently enough to prune the idle metrics.
-    ///
-    /// Further, the metric kind "mask" configures which metrics will be considered by the idle
-    /// timeout.  If the kind of a metric being considered for idle timeout is not of a kind
-    /// represented by the mask, it will not be affected, even if it would have othered been removed
-    /// for exceeding the idle timeout.
-    ///
-    /// Refer to the documentation for [`MetricKindMask`](metrics_util::MetricKindMask) for more
-    /// information on defining a metric kind mask.
-    #[must_use]
-    pub fn idle_timeout(self, mask: MetricKindMask, timeout: Option<Duration>) -> Self {
-        Self {
-            inner: self.inner.idle_timeout(mask, timeout),
-        }
-    }
-
-    /// Adds a global label to this exporter.
-    ///
-    /// Global labels are applied to all metrics.  Labels defined on the metric key itself have precedence
-    /// over any global labels.  If this method is called multiple times, the latest value for a given label
-    /// key will be used.
-    #[must_use]
-    pub fn add_global_label<K, V>(self, key: K, value: V) -> Self
-    where
-        K: Into<String>,
-        V: Into<String>,
-    {
-        Self {
-            inner: self.inner.add_global_label(key, value),
-        }
-    }
-
-    fn try_map(
-        self,
-        f: impl FnOnce(InnerBuilder) -> Result<InnerBuilder, BuildError>,
-    ) -> Result<Self, BuildError> {
-        Ok(Self {
-            inner: f(self.inner)?,
-        })
-    }
 }
 
 impl Prometheus {

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -47,7 +47,7 @@ impl PrometheusBuilder {
     /// ## Errors
     ///
     /// If `quantiles` is empty, an error variant will be thrown.
-    pub fn set_quantiles(mut self, quantiles: &[f64]) -> Result<Self, BuildError> {
+    pub fn set_quantiles(self, quantiles: &[f64]) -> Result<Self, BuildError> {
         self.try_map(|inner| inner.set_quantiles(quantiles))
     }
 
@@ -59,7 +59,7 @@ impl PrometheusBuilder {
     /// ## Errors
     ///
     /// If `values` is empty, an error variant will be thrown.
-    pub fn set_buckets(mut self, values: &[f64]) -> Result<Self, BuildError> {
+    pub fn set_buckets(self, values: &[f64]) -> Result<Self, BuildError> {
         self.try_map(|inner| inner.set_buckets(values))
     }
 
@@ -80,7 +80,7 @@ impl PrometheusBuilder {
     ///
     /// If `values` is empty, an error variant will be thrown.
     pub fn set_buckets_for_metric(
-        mut self,
+        self,
         matcher: Matcher,
         values: &[f64],
     ) -> Result<Self, BuildError> {
@@ -102,7 +102,7 @@ impl PrometheusBuilder {
     /// Refer to the documentation for [`MetricKindMask`](metrics_util::MetricKindMask) for more
     /// information on defining a metric kind mask.
     #[must_use]
-    pub fn idle_timeout(mut self, mask: MetricKindMask, timeout: Option<Duration>) -> Self {
+    pub fn idle_timeout(self, mask: MetricKindMask, timeout: Option<Duration>) -> Self {
         Self {
             inner: self.inner.idle_timeout(mask, timeout),
             ..self
@@ -115,7 +115,7 @@ impl PrometheusBuilder {
     /// over any global labels.  If this method is called multiple times, the latest value for a given label
     /// key will be used.
     #[must_use]
-    pub fn add_global_label<K, V>(mut self, key: K, value: V) -> Self
+    pub fn add_global_label<K, V>(self, key: K, value: V) -> Self
     where
         K: Into<String>,
         V: Into<String>,

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,23 +1,24 @@
-use super::*;
-
-use hyper::header;
+use hyper::{header, Body, Request, Response, StatusCode};
+use ipnet::IpNet;
 pub use metrics_exporter_prometheus::{BuildError, Matcher};
 use metrics_exporter_prometheus::{PrometheusBuilder as InnerBuilder, PrometheusHandle};
 use metrics_process::Collector;
 pub use metrics_util::MetricKindMask;
 
-use std::{fmt, time::Duration};
+use std::{fmt, net::IpAddr, sync::Arc, time::Duration};
 
 #[derive(Default)]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "admin", feature = "metrics"))))]
 pub struct PrometheusBuilder {
     inner: InnerBuilder,
+    allowed_nets: Option<Vec<IpNet>>,
 }
 
 #[derive(Clone)]
 pub(super) struct Prometheus {
     metrics: PrometheusHandle,
     process: Collector,
+    allowed_nets: Option<Arc<[IpNet]>>,
 }
 
 // === impl PrometheusBuilder ===
@@ -27,6 +28,7 @@ impl PrometheusBuilder {
     pub fn new() -> Self {
         Self {
             inner: InnerBuilder::new(),
+            allowed_nets: None,
         }
     }
 
@@ -103,6 +105,7 @@ impl PrometheusBuilder {
     pub fn idle_timeout(mut self, mask: MetricKindMask, timeout: Option<Duration>) -> Self {
         Self {
             inner: self.inner.idle_timeout(mask, timeout),
+            ..self
         }
     }
 
@@ -119,7 +122,38 @@ impl PrometheusBuilder {
     {
         Self {
             inner: self.inner.add_global_label(key, value),
+            ..self
         }
+    }
+    /// Adds an IP address or subnet to the allowlist for the scrape endpoint.
+    ///
+    /// If a client makes a request to the scrape endpoint and their IP is not present in the
+    /// allowlist, either directly or within any of the allowed subnets, they will receive a 403
+    /// Forbidden response.
+    ///
+    /// Defaults to allowing all IPs.
+    ///
+    /// ## Security Considerations
+    ///
+    /// On its own, an IP allowlist is insufficient for access control, if the exporter is running
+    /// in an environment alongside applications (such as web browsers) that are susceptible to [DNS
+    /// rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks.
+    ///
+    /// ## Errors
+    ///
+    /// If the given address cannot be parsed into an IP address or subnet, an error variant will be
+    /// returned describing the error.
+    pub fn add_allowed_address<A>(mut self, address: A) -> Result<Self, BuildError>
+    where
+        A: AsRef<str>,
+    {
+        use std::str::FromStr;
+
+        let address = IpNet::from_str(address.as_ref())
+            .map_err(|e| BuildError::InvalidAllowlistAddress(e.to_string()))?;
+        self.allowed_nets.get_or_insert_with(Vec::new).push(address);
+
+        Ok(self)
     }
 
     fn try_map(
@@ -128,26 +162,59 @@ impl PrometheusBuilder {
     ) -> Result<Self, BuildError> {
         Ok(Self {
             inner: f(self.inner)?,
+            ..self
         })
     }
 }
 
+impl fmt::Debug for PrometheusBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrometheusBuilder")
+            // this type from `metrics-exporter-prometheus` doesn't implement `Debug`...
+            .field("inner", &format_args!("PrometheusBuilder {{ ... }}"))
+            .field("allowed_nets", &self.allowed_nets)
+            .finish()
+    }
+}
+
+// === impl Prometheus ===
+
 impl Prometheus {
     pub(super) fn new(builder: PrometheusBuilder) -> Self {
         let metrics = builder
+            .inner
             .install_recorder()
             .expect("failed to install Prometheus recorder");
+        let allowed_nets = builder.allowed_nets.map(Into::into);
         let process = Collector::default();
         process.describe();
-        Self { metrics, process }
+        Self {
+            metrics,
+            process,
+            allowed_nets,
+        }
     }
 
-    pub(super) fn handle_metrics(&self, req: Request<Body>) -> Response<Body> {
+    pub(super) fn handle_metrics(&self, remote_ip: IpAddr, req: Request<Body>) -> Response<Body> {
+        // If the allowlist is empty, the request is allowed.  Otherwise, it must
+        // match one of the entries in the allowlist or it will be denied.
+        let allowed = self.allowed_nets.as_ref().map_or(true, |addresses| {
+            addresses.iter().any(|address| address.contains(&remote_ip))
+        });
+
+        if !allowed {
+            tracing::info!("Denying metrics scrape from {remote_ip}; address not in allowlist");
+            return Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body(Body::default())
+                .unwrap();
+        }
+
         self.process.collect();
         match *req.method() {
             hyper::Method::GET | hyper::Method::HEAD => {
                 let mut rsp = Response::builder()
-                    .status(hyper::StatusCode::OK)
+                    .status(StatusCode::OK)
                     .header(header::CONTENT_TYPE, "text/plain");
 
                 let metrics = self.metrics.render();
@@ -166,7 +233,7 @@ impl Prometheus {
                 rsp.body(body).unwrap()
             }
             _ => Response::builder()
-                .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
+                .status(StatusCode::METHOD_NOT_ALLOWED)
                 .header(header::ALLOW, "GET, HEAD")
                 .body(Body::default())
                 .unwrap(),
@@ -178,6 +245,7 @@ impl fmt::Debug for Prometheus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Prometheus")
             .field("metrics", &format_args!("PrometheusHandle {{ ... }}"))
+            .field("allowed_nets", &self.allowed_nets)
             .field("process", &self.process)
             .finish()
     }

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+pub(super) use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::PrometheusHandle;
+use metrics_process::Collector;
+
+use std::fmt;
+
+#[derive(Clone)]
+pub(super) struct Prometheus {
+    metrics: PrometheusHandle,
+    process: Collector,
+}
+
+impl Prometheus {
+    pub(super) fn new(builder: PrometheusBuilder) -> Self {
+        let metrics = builder
+            .install_recorder()
+            .expect("failed to install Prometheus recorder");
+        let process = Collector::default();
+        process.describe();
+        Self { metrics, process }
+    }
+
+    pub(super) fn handle_metrics(&self, req: Request<Body>) -> Response<Body> {
+        self.process.collect();
+        match *req.method() {
+            hyper::Method::GET | hyper::Method::HEAD => Response::builder()
+                .status(hyper::StatusCode::OK)
+                .header(hyper::header::CONTENT_TYPE, "text/plain")
+                .body(self.metrics.render().into())
+                .unwrap(),
+            _ => Response::builder()
+                .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
+                .body(Body::default())
+                .unwrap(),
+        }
+    }
+}
+
+impl fmt::Debug for Prometheus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Prometheus")
+            .field("metrics", &format_args!("..."))
+            .field("process", &self.process)
+            .finish()
+    }
+}

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -58,7 +58,7 @@ impl Prometheus {
 impl fmt::Debug for Prometheus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Prometheus")
-            .field("metrics", &format_args!("PrometheusHandle { ... }"))
+            .field("metrics", &format_args!("PrometheusHandle {{ ... }}"))
             .field("process", &self.process)
             .finish()
     }

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -32,6 +32,7 @@ impl Prometheus {
                 .unwrap(),
             _ => Response::builder()
                 .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
+                .header(hyper::header::ALLOW, "GET, HEAD")
                 .body(Body::default())
                 .unwrap(),
         }

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,16 +1,135 @@
 use super::*;
 
 use hyper::header;
-pub(super) use metrics_exporter_prometheus::PrometheusBuilder;
-use metrics_exporter_prometheus::PrometheusHandle;
+pub use metrics_exporter_prometheus::{BuildError, Matcher};
+use metrics_exporter_prometheus::{PrometheusBuilder as InnerBuilder, PrometheusHandle};
 use metrics_process::Collector;
+pub use metrics_util::MetricKindMask;
 
-use std::fmt;
+use std::{fmt, time::Duration};
+
+#[derive(Default)]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "admin", feature = "metrics"))))]
+pub struct PrometheusBuilder {
+    inner: InnerBuilder,
+}
 
 #[derive(Clone)]
 pub(super) struct Prometheus {
     metrics: PrometheusHandle,
     process: Collector,
+}
+
+// === impl PrometheusBuilder ===
+
+impl PrometheusBuilder {
+    /// Creates a new [`PrometheusBuilder`].
+    pub fn new() -> Self {
+        Self {
+            inner: InnerBuilder::new(),
+        }
+    }
+
+    /// Sets the quantiles to use when rendering histograms.
+    ///
+    /// Quantiles represent a scale of 0 to 1, where percentiles represent a scale of 1 to 100, so
+    /// a quantile of 0.99 is the 99th percentile, and a quantile of 0.99 is the 99.9th percentile.
+    ///
+    /// Defaults to a hard-coded set of quantiles: 0.0, 0.5, 0.9, 0.95, 0.99, 0.999, and 1.0. This means
+    /// that all histograms will be exposed as Prometheus summaries.
+    ///
+    /// If buckets are set (via [`set_buckets`][Self::set_buckets] or
+    /// [`set_buckets_for_metric`][Self::set_buckets_for_metric]) then all histograms will be exposed
+    /// as summaries instead.
+    ///
+    /// ## Errors
+    ///
+    /// If `quantiles` is empty, an error variant will be thrown.
+    pub fn set_quantiles(mut self, quantiles: &[f64]) -> Result<Self, BuildError> {
+        self.try_map(|inner| inner.set_quantiles(quantiles))
+    }
+
+    /// Sets the buckets to use when rendering histograms.
+    ///
+    /// Buckets values represent the higher bound of each buckets.  If buckets are set, then all
+    /// histograms will be rendered as true Prometheus histograms, instead of summaries.
+    ///
+    /// ## Errors
+    ///
+    /// If `values` is empty, an error variant will be thrown.
+    pub fn set_buckets(mut self, values: &[f64]) -> Result<Self, BuildError> {
+        self.try_map(|inner| inner.set_buckets(values))
+    }
+
+    /// Sets the bucket for a specific pattern.
+    ///
+    /// The match pattern can be a full match (equality), prefix match, or suffix match.  The
+    /// matchers are applied in that order if two or more matchers would apply to a single metric.
+    /// That is to say, if a full match and a prefix match applied to a metric, the full match would
+    /// win, and if a prefix match and a suffix match applied to a metric, the prefix match would win.
+    ///
+    /// Buckets values represent the higher bound of each buckets.  If buckets are set, then any
+    /// histograms that match will be rendered as true Prometheus histograms, instead of summaries.
+    ///
+    /// This option changes the observer's output of histogram-type metric into summaries.
+    /// It only affects matching metrics if [`set_buckets`][Self::set_buckets] was not used.
+    ///
+    /// ## Errors
+    ///
+    /// If `values` is empty, an error variant will be thrown.
+    pub fn set_buckets_for_metric(
+        mut self,
+        matcher: Matcher,
+        values: &[f64],
+    ) -> Result<Self, BuildError> {
+        self.try_map(|inner| inner.set_buckets_for_metric(matcher, values))
+    }
+
+    /// Sets the idle timeout for metrics.
+    ///
+    /// If a metric hasn't been updated within this timeout, it will be removed from the registry
+    /// and in turn removed from the normal scrape output until the metric is emitted again.  This
+    /// behavior is driven by requests to generate rendered output, and so metrics will not be
+    /// removed unless a request has been made recently enough to prune the idle metrics.
+    ///
+    /// Further, the metric kind "mask" configures which metrics will be considered by the idle
+    /// timeout.  If the kind of a metric being considered for idle timeout is not of a kind
+    /// represented by the mask, it will not be affected, even if it would have othered been removed
+    /// for exceeding the idle timeout.
+    ///
+    /// Refer to the documentation for [`MetricKindMask`](metrics_util::MetricKindMask) for more
+    /// information on defining a metric kind mask.
+    #[must_use]
+    pub fn idle_timeout(mut self, mask: MetricKindMask, timeout: Option<Duration>) -> Self {
+        Self {
+            inner: self.inner.idle_timeout(mask, timeout),
+        }
+    }
+
+    /// Adds a global label to this exporter.
+    ///
+    /// Global labels are applied to all metrics.  Labels defined on the metric key itself have precedence
+    /// over any global labels.  If this method is called multiple times, the latest value for a given label
+    /// key will be used.
+    #[must_use]
+    pub fn add_global_label<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        Self {
+            inner: self.inner.add_global_label(key, value),
+        }
+    }
+
+    fn try_map(
+        self,
+        f: impl FnOnce(InnerBuilder) -> Result<InnerBuilder, BuildError>,
+    ) -> Result<Self, BuildError> {
+        Ok(Self {
+            inner: f(self.inner)?,
+        })
+    }
 }
 
 impl Prometheus {

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -58,7 +58,7 @@ impl Prometheus {
 impl fmt::Debug for Prometheus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Prometheus")
-            .field("metrics", &format_args!("..."))
+            .field("metrics", &format_args!("PrometheusHandle { ... }"))
             .field("process", &self.process)
             .finish()
     }

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,3 +1,11 @@
+//! Configuration for serving a [Prometheus] metrics endpoint using the
+//! [`metrics`] crate.
+//!
+//! The [`PrometheusBuilder`] type in this module configures how Prometheus
+//! metrics are served.
+//!
+//! [Prometheus]: https://prometheus.io/
+//! [`metrics`]: https://crates.io/crates/metrics
 use hyper::{header, Body, Request, Response, StatusCode};
 use ipnet::IpNet;
 pub use metrics_exporter_prometheus::{BuildError, Matcher};
@@ -7,6 +15,13 @@ pub use metrics_util::MetricKindMask;
 
 use std::{fmt, net::IpAddr, sync::Arc, time::Duration};
 
+/// Configures an admin server's [Prometheus] metrics endpoint.
+///
+/// This builder is passed to the [`admin::Builder::with_prometheus`] method to
+/// enable the metrics endpoint.
+///
+/// [Prometheus]: https://prometheus.io/
+/// [`admin::Builder::with_prometheus`]: super::Builder::with_prometheus
 #[derive(Default)]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "admin", feature = "metrics"))))]
 pub struct PrometheusBuilder {
@@ -25,6 +40,7 @@ pub(super) struct Prometheus {
 
 impl PrometheusBuilder {
     /// Creates a new [`PrometheusBuilder`].
+    #[must_use]
     pub fn new() -> Self {
         Self {
             inner: InnerBuilder::new(),


### PR DESCRIPTION
This branch builds on PR #107 to add a production-ready Prometheus
metrics endpoint. As discussed in #107, the metrics endpoint is
implemented using the `metrics-endpoint-prometheus` and
`metrics-process` crates, and will serve process metrics by default. If
the application or other libraries use the `metrics` crate to emit their
own metrics, these metrics will be included in the Prometheus endpoint
as well.

Changes from #107 include the following:

- The metrics endpoint is feature-flagged behind the "metrics" feature.
- Metrics are compressed using GZIP when the request includes an
  `accept-encoding: gzip` header
- The `PrometheusBuilder` type from `metrics-exporter-prometheus` is
  wrapped in a newtype. This is because `metrics-exporter-prometheus`
  includes functionality for configuring an allowlist of allowed IP
  networks, which will deny any requests not sent by one of those IP
  addresses. If this is configured using
  `metrics_exporter_prometheus::PrometheusBuilder` and then the builder
  is passed to `kubert`, however, the allowlist will not work.
  Therefore, we can wrap the builder in our own type that passes through
  most of the methods and re-implements the allowlist functionality. In
  addition, other `metrics-*` types used by kubert are re-exported from
  the `admin::metrics` module so that they can be used without requiring
  an import of the various `metrics-*` crates in the end-user project.

Closes #107
Closes adleong/kubert#1