### PR TITLE
Remove Claim `non_exhaustive`

### DIFF
--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -35,7 +35,6 @@ pub struct ClaimParams {
 /// Describes the state of a lease
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "lease")))]
-#[non_exhaustive]
 pub struct Claim {
     /// The identity of the claim holder.
     pub holder: String,


### PR DESCRIPTION
This will allow kubert users to create Claims. This will be useful for mocking
Claim watches in tests

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
