### PR TITLE
style: fix clippy auto-deref lints

### DIFF
--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
             let released = kubert::LeaseManager::init(api, name)
                 .await?
                 .with_field_manager(field_manager)
-                .vacate(&*identity)
+                .vacate(&identity)
                 .await?;
             let code = if released {
                 println!("+ Claim vacated");
@@ -181,7 +181,7 @@ async fn main() -> Result<()> {
                 .with_field_manager(field_manager);
             let (mut claims, task) = lease.spawn(&identity, params).await?;
             loop {
-                print_claim(&*claims.borrow_and_update(), &identity);
+                print_claim(&claims.borrow_and_update(), &identity);
 
                 let shutdown = shutdown.clone();
                 tokio::select! {

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -133,7 +133,7 @@ impl LeaseManager {
     /// will be returned.
     pub async fn init(api: Api, name: impl ToString) -> Result<Self, Error> {
         let name = name.to_string();
-        let state = Self::get(api.clone(), &*name).await?;
+        let state = Self::get(api.clone(), &name).await?;
         Ok(Self {
             api,
             name,
@@ -191,7 +191,7 @@ impl LeaseManager {
                         Err(e) if Self::is_conflict(&e) => {
                             // Another process updated the claim's resource version, so
                             // re-sync the state and try again.
-                            *state = Self::get(self.api.clone(), &*self.name).await?;
+                            *state = Self::get(self.api.clone(), &self.name).await?;
                             continue;
                         }
                         Err(e) => return Err(e),
@@ -215,7 +215,7 @@ impl LeaseManager {
                 Err(e) if Self::is_conflict(&e) => {
                     // Another process updated the claim's resource version, so
                     // re-sync the state and try again.
-                    *state = Self::get(self.api.clone(), &*self.name).await?;
+                    *state = Self::get(self.api.clone(), &self.name).await?;
                     continue;
                 }
                 Err(e) => return Err(e),
@@ -420,7 +420,7 @@ impl LeaseManager {
             force: matches!(patch, kube_client::api::Patch::Apply(_)),
             ..Default::default()
         };
-        self.api.patch(&*self.name, &params, patch).await
+        self.api.patch(&self.name, &params, patch).await
     }
 
     async fn get(api: Api, name: &str) -> Result<State, Error> {


### PR DESCRIPTION
Clippy emits a warning when an explicit dereference (`*`) is used for a deref coercion that would be performed automatically by the compiler. This branch fixes a few of those warnings.