### PR TITLE
lease: don't terminate `LeaseManager` on `ensure_claimed` errors

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -24,6 +24,7 @@ errors = [
     "futures-core",
     "futures-util",
     "pin-project-lite",
+    "rand",
     "tokio/time",
     "tracing",
 ]
@@ -115,6 +116,7 @@ parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 metrics-exporter-prometheus = { version = "0.11.0", optional = true, default-features = false }
 metrics-process = { version = "1.0.4", optional = true }
+rand = { version = "0.8", features = ["small_rng"], optional = true }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }
@@ -164,6 +166,7 @@ features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"]
 
 [dev-dependencies]
 kube = { version = "0.80", default-features = false, features = ["runtime"] }
+quickcheck = { version = "1", default-features = false }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
@@ -177,3 +180,4 @@ features = ["v1_26"]
 version = "1.18"
 default-features = false
 features = ["macros", "test-util"]
+

--- a/kubert/src/errors.rs
+++ b/kubert/src/errors.rs
@@ -9,6 +9,9 @@ use std::{
 use tokio::time;
 use tracing::info;
 
+pub mod backoff;
+pub use self::backoff::ExponentialBackoff;
+
 pin_project_lite::pin_project! {
     /// Wraps a [`Stream`], handling errors by logging them and applying a backoff
     ///

--- a/kubert/src/errors/backoff.rs
+++ b/kubert/src/errors/backoff.rs
@@ -1,0 +1,211 @@
+//! Jittered exponeitial backoffs for retrying fallible operations.
+use futures_core::Stream;
+use rand::{rngs::SmallRng, thread_rng, SeedableRng};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+use tokio::time;
+
+/// A jittered exponential backoff strategy.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ExponentialBackoff {
+    /// The minimum amount of time to wait before resuming an operation.
+    min: time::Duration,
+
+    /// The maximum amount of time to wait before resuming an operation.
+    max: time::Duration,
+
+    /// The ratio of the base timeout that may be randomly added to a backoff.
+    ///
+    /// Must be greater than or equal to 0.0.
+    jitter: f64,
+}
+pin_project_lite::pin_project! {
+    /// A jittered exponential backoff stream.
+    #[derive(Debug)]
+    pub struct ExponentialBackoffStream {
+        backoff: ExponentialBackoff,
+        rng: SmallRng,
+        iterations: u32,
+        sleeping: bool,
+        sleep: Pin<Box<time::Sleep>>,
+    }
+}
+
+/// Errors returned by [`ExponentialBackoff::try_new`].
+#[derive(Clone, Debug, Error)]
+#[error("invalid backoff: {0}")]
+pub struct InvalidBackoff(&'static str);
+
+impl ExponentialBackoff {
+    /// Returns a new `ExponentialBackoff` with the given `min` and `max`
+    /// backoff durations and the provided random `jitter`.
+    ///
+    /// This constructor does not validate that the backoff parameters are
+    /// valid. In order to validate the backoff parameters, use
+    /// [`ExponentialBackoff::try_new`] (which is not a `const fn`), instead.
+    #[must_use]
+    pub const fn new_unchecked(min: time::Duration, max: time::Duration, jitter: f64) -> Self {
+        Self { min, max, jitter }
+    }
+
+    /// Returns a new `ExponentialBackoff` with with the given `min` and `max`
+    /// backoff durations and the provided random `jitter`, or an
+    /// `InvalidBackoff` error if the provided parameters are invalid.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(ExponentialBackoff)` if the provided parameters are valid.
+    /// - `Err(InvalidBackoff)` if:
+    ///    - `max` is less than `min`.
+    ///    - `max` is 0.
+    ///    - `jitter` is less than 0 or greater than 100.
+    ///    - `jitter` is not a finite number.
+    pub fn try_new(
+        min: time::Duration,
+        max: time::Duration,
+        jitter: f64,
+    ) -> Result<Self, InvalidBackoff> {
+        if min > max {
+            return Err(InvalidBackoff("maximum must not be less than minimum"));
+        }
+        if max == time::Duration::from_millis(0) {
+            return Err(InvalidBackoff("maximum must be non-zero"));
+        }
+        if jitter < 0.0 {
+            return Err(InvalidBackoff("jitter must not be negative"));
+        }
+        if jitter > 100.0 {
+            return Err(InvalidBackoff("jitter must not be greater than 100"));
+        }
+        if !jitter.is_finite() {
+            return Err(InvalidBackoff("jitter must be finite"));
+        }
+        Ok(ExponentialBackoff { min, max, jitter })
+    }
+
+    /// Returns a [`Stream`] of backoff durations generated from this
+    /// exponential backoff strategy.
+    #[must_use]
+    pub fn stream(&self) -> ExponentialBackoffStream {
+        ExponentialBackoffStream {
+            backoff: *self,
+            rng: SmallRng::from_rng(&mut thread_rng()).expect("RNG must be valid"),
+            iterations: 0,
+            sleeping: false,
+            sleep: Box::pin(time::sleep(time::Duration::from_secs(0))),
+        }
+    }
+
+    fn base(&self, iterations: u32) -> time::Duration {
+        debug_assert!(
+            self.min <= self.max,
+            "maximum backoff must not be less than minimum backoff"
+        );
+        debug_assert!(
+            self.max > time::Duration::from_millis(0),
+            "Maximum backoff must be non-zero"
+        );
+        self.min
+            .checked_mul(2_u32.saturating_pow(iterations))
+            .unwrap_or(self.max)
+            .min(self.max)
+    }
+
+    /// Returns a random, uniform duration on `[0, base*self.jitter]` no greater
+    /// than `self.max`.
+    fn jitter<R: rand::Rng>(&self, base: time::Duration, rng: &mut R) -> time::Duration {
+        if self.jitter == 0.0 {
+            time::Duration::default()
+        } else {
+            let jitter_factor = rng.gen::<f64>();
+            debug_assert!(
+                jitter_factor > 0.0,
+                "rng returns values between 0.0 and 1.0"
+            );
+            let rand_jitter = jitter_factor * self.jitter;
+            let secs = (base.as_secs() as f64) * rand_jitter;
+            let nanos = (base.subsec_nanos() as f64) * rand_jitter;
+            let remaining = self.max - base;
+            time::Duration::new(secs as u64, nanos as u32).min(remaining)
+        }
+    }
+}
+
+impl Stream for ExponentialBackoffStream {
+    type Item = ();
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        loop {
+            // If there's an active delay, wait until it's done and then
+            // update the state.
+            if *this.sleeping {
+                futures_core::ready!(this.sleep.as_mut().poll(cx));
+
+                *this.sleeping = false;
+                *this.iterations += 1;
+                return Poll::Ready(Some(()));
+            }
+            if *this.iterations == u32::MAX {
+                return Poll::Ready(None);
+            }
+
+            let backoff = {
+                let base = this.backoff.base(*this.iterations);
+                base + this.backoff.jitter(base, &mut this.rng)
+            };
+            this.sleep.as_mut().reset(time::Instant::now() + backoff);
+            *this.sleeping = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::*;
+
+    quickcheck! {
+        fn backoff_base_first(min_ms: u64, max_ms: u64) -> TestResult {
+            let min = time::Duration::from_millis(min_ms);
+            let max = time::Duration::from_millis(max_ms);
+            let backoff = match ExponentialBackoff::try_new(min, max, 0.0) {
+                Err(_) => return TestResult::discard(),
+                Ok(backoff) => backoff,
+            };
+            let delay = backoff.base(0);
+            TestResult::from_bool(min == delay)
+        }
+
+        fn backoff_base(min_ms: u64, max_ms: u64, iterations: u32) -> TestResult {
+            let min = time::Duration::from_millis(min_ms);
+            let max = time::Duration::from_millis(max_ms);
+            let backoff = match ExponentialBackoff::try_new(min, max, 0.0) {
+                Err(_) => return TestResult::discard(),
+                Ok(backoff) => backoff,
+            };
+            let delay = backoff.base(iterations);
+            TestResult::from_bool(min <= delay && delay <= max)
+        }
+
+        fn backoff_jitter(base_ms: u64, max_ms: u64, jitter: f64) -> TestResult {
+            let base = time::Duration::from_millis(base_ms);
+            let max = time::Duration::from_millis(max_ms);
+            let backoff = match ExponentialBackoff::try_new(base, max, jitter) {
+                Err(_) => return TestResult::discard(),
+                Ok(backoff) => backoff,
+            };
+
+            let j = backoff.jitter(base, &mut rand::thread_rng());
+            if jitter == 0.0 || base_ms == 0 || max_ms == base_ms {
+                TestResult::from_bool(j == time::Duration::default())
+            } else {
+                TestResult::from_bool(j > time::Duration::default())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, if the `ensure_claimed` call in the `LeaseManager::spawn` background task fails, the entire task will bail and terminate immediately. This is not desirable, as the intended use of `LeaseManager::spawn` is to spawn a single background task that will manage leasses for the entire lifetime of a controller process, and it should not terminate in the face of a transient error claiming the lease.

This branch changes `LeaseManager::spawn` to log the error and continue looping, rather than bailing out. We may want to consider adding some kind of retry backoff logic here as well, but this solution still seems better than simply bailing o34ut.

Fixes #134