### PR TITLE
chore: allow duplicate versions of `hermit-abi` and `bitflags`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -50,10 +50,6 @@ skip = [
     # `rustls-pemfile` and `k8s-openapi` depend on versions of `base64` that
     # have diverged significantly.
     { name = "base64" },
-    # `num_cpus` (transitive dep of `metrics-util` and `tokio`) and
-    # `io-lifetimes` (a transitive dep of `metrics-process`) depend on
-    # incompatible versions of this crate.
-    { name = "hermit-abi" },
 ]
 skip-tree = [
     { name = "windows-sys" },
@@ -66,6 +62,11 @@ skip-tree = [
     # `wasi`.
     # TODO(eliza): remove this skip when the conflicts are resolved.
     { name = "metrics" },
+    # `metrics-process` has transitive deps on `hermit-abi` and `bitflags` that
+    # are incompatible with the transitive deps other crates have on those
+    # libraries.
+    # TODO(eliza): remove this skip when the conflicts are resolved.
+    { name = "metrics-process" }
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -50,6 +50,10 @@ skip = [
     # `rustls-pemfile` and `k8s-openapi` depend on versions of `base64` that
     # have diverged significantly.
     { name = "base64" },
+    # `num_cpus` (transitive dep of `metrics-util` and `tokio`) and
+    # `io-lifetimes` (a transitive dep of `metrics-process`) depend on
+    # incompatible versions of this crate.
+    { name = "hermit-abi" },
 ]
 skip-tree = [
     { name = "windows-sys" },


### PR DESCRIPTION
Our `cargo deny` checks are failing because `num_cpus` (a transitive dep of `metrics-util` and `tokio`) and `io-lifetimes` (a transitive dep of `metrics-process`) depend on incompatible versions of...whatever this crate is...