### PR TITLE
Allow runtime to accept an admin builder

### DIFF
--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -85,6 +85,18 @@ impl AdminArgs {
 
 // === impl Builder ===
 
+impl Default for Builder {
+    fn default() -> Self {
+        AdminArgs::default().into_builder()
+    }
+}
+
+impl From<AdminArgs> for Builder {
+    fn from(args: AdminArgs) -> Self {
+        args.into_builder()
+    }
+}
+
 impl Builder {
     /// Creates a new [`Builder`] with the given server address
     ///

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "server")]
 use crate::server::{self, ServerArgs};
 use crate::{
-    admin::{self, AdminArgs, Readiness},
+    admin::{self, Readiness},
     client::{self, Client, ClientArgs},
     errors,
     initialized::{self, Initialized},
@@ -25,7 +25,7 @@ pub use reflector::Store;
 #[cfg_attr(docsrs, doc(cfg(feature = "runtime")))]
 #[must_use]
 pub struct Builder<S = NoServer> {
-    admin: Option<AdminArgs>,
+    admin: admin::Builder,
     client: Option<ClientArgs>,
     error_delay: Option<Duration>,
     log: Option<LogSettings>,
@@ -103,8 +103,8 @@ impl<S> Builder<S> {
     const DEFAULT_ERROR_DELAY: Duration = Duration::from_secs(5);
 
     /// Configures the runtime to use the given [`AdminArgs`]
-    pub fn with_admin(mut self, admin: AdminArgs) -> Self {
-        self.admin = Some(admin);
+    pub fn with_admin(mut self, admin: impl Into<admin::Builder>) -> Self {
+        self.admin = admin.into();
         self
     }
 
@@ -131,7 +131,7 @@ impl<S> Builder<S> {
         self.log.unwrap_or_default().try_init()?;
         let client = self.client.unwrap_or_default().try_client().await?;
         let (shutdown, shutdown_rx) = shutdown::sigint_or_sigterm()?;
-        let admin = self.admin.unwrap_or_default().into_builder().bind()?;
+        let admin = self.admin.bind()?;
         Ok(Runtime {
             client,
             shutdown_rx,

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -102,7 +102,7 @@ struct LogSettings {
 impl<S> Builder<S> {
     const DEFAULT_ERROR_DELAY: Duration = Duration::from_secs(5);
 
-    /// Configures the runtime to use the given [`AdminArgs`]
+    /// Configures the runtime to use the given [`Builder`]
     pub fn with_admin(mut self, admin: impl Into<admin::Builder>) -> Self {
         self.admin = admin.into();
         self


### PR DESCRIPTION
We update the runtime builder's `with_admin` function to accept a `impl Into<admin::Builder>` rather than a `AdminArgs`.  This gives callers the flexibility of providing their own `admin::Builder` if they need to customize it.

For example:

```
    let mut admin = admin_args.into_builder();
    admin.with_default_prometheus();

    let mut runtime = kubert::Runtime::builder()
        .with_log(log_level, log_format)
        .with_admin(admin)
```