### PR TITLE
lease: retry errors claiming lease in `LeaseManager::spawn`

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -38,6 +38,7 @@ index = [
 ]
 initialized = ["futures-core", "futures-util", "pin-project-lite", "tokio/sync"]
 lease = [
+    "backoff",
     "chrono",
     "hyper",
     "k8s-openapi",
@@ -103,6 +104,7 @@ features = ["k8s-openapi/v1_26"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
+backoff = { version = "0.4", features = ["tokio"], optional = true }
 deflate = { version = "1", optional = true, default-features = false, features = [
     "gzip",
 ] }

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -320,7 +320,7 @@ impl LeaseManager {
                             backoff::Error::Permanent(err)
                         },
                         // Retry any other API request errors.
-                        err @ Error::Api(_) => {
+                        err => {
                             tracing::debug!(error = %err, "Error claiming lease, retrying...");
                             backoff::Error::Transient {
                                 err,
@@ -329,7 +329,6 @@ impl LeaseManager {
                                 retry_after: None,
                             }
                         }
-                        err @ Error::MissingResourceVersion | err @ Error::MissingSpec => backoff::Error::Permanent(err),
                     })
                 })
                 .await?;

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -126,7 +126,7 @@ impl Claim {
 
 impl LeaseManager {
     const DEFAULT_FIELD_MANAGER: &'static str = "kubert";
-    const DEFAULT_MIN_BACKOFF: Duration = Duration::from_secs(2);
+    const DEFAULT_MIN_BACKOFF: Duration = Duration::from_millis(5);
     const DEFAULT_BACKOFF_JITTER: f64 = 0.5; // up to 50% of the backoff duration
 
     /// Initialize a lease's state from the Kubernetes API.


### PR DESCRIPTION
Currently, if the `ensure_claimed` call in the `LeaseManager::spawn`
background task fails, the entire task will bail and terminate
immediately. This is not desirable, as the intended use of
`LeaseManager::spawn` is to spawn a single background task that will
manage leasses for the entire lifetime of a controller process, and it
should not terminate in the face of a transient error claiming the
lease.

This branch changes `LeaseManager::spawn` to retry transient errors with
an exponential backoff strategy. Exponential backoffs are implemented
using the `backoff` crate, but --- because this dependency is not
exposed in the public API -- this is strictly an implementation detail,
and the dependency can be swapped out for another exponential backoff
implementation later, if desired. Errors marked as transient and retried
include network errors communicating with the API server, errors parsing
the API server response, and HTTP error statuses returned by the API
server. Errors that result from a bad configuration or missing
permissions are treated as fatal, as they are unlikely to ever succeed
after retrying.

Closes #137
Closes #136