### PR TITLE
client: Allow constructing client from a `Service`

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -19,7 +19,14 @@ admin = [
     "tokio/sync",
     "tracing",
 ]
-client = ["kube-client", "thiserror"]
+client = [
+    "bytes",
+    "kube-client",
+    "thiserror",
+    "tower",
+    "tower/util",
+    "hyper",
+]
 errors = [
     "futures-core",
     "futures-util",
@@ -85,7 +92,7 @@ server = [
     "tokio/net",
     "tokio/rt",
     "tokio-rustls",
-    "tower-service",
+    "tower",
     "tracing",
 ]
 shutdown = [
@@ -105,6 +112,7 @@ features = ["k8s-openapi/v1_26"]
 [dependencies]
 ahash = { version = "0.8", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
+bytes = { version = "1", optional = true }
 deflate = { version = "1", optional = true, default-features = false, features = [
     "gzip",
 ] }
@@ -124,7 +132,7 @@ serde_json = { version = "1", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }
 tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.23.2", optional = true, default-features = false }
-tower-service = { version = "0.3.1", optional = true }
+tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 [dependencies.clap]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -25,6 +25,7 @@ client = [
     "thiserror",
     "tower",
     "tower/util",
+    "tower-http",
     "hyper",
 ]
 errors = [
@@ -34,6 +35,7 @@ errors = [
     "tokio/time",
     "tracing",
 ]
+gzip = ["tower-http?/decompression-gzip"]
 index = [
     "ahash",
     "futures-core",
@@ -132,6 +134,7 @@ serde_json = { version = "1", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }
 tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.23.2", optional = true, default-features = false }
+tower-http = { version = "0.4.0", optional = true, default-features = false, features = ["map-response-body"] }
 tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -198,8 +198,8 @@ impl Builder<NoServer> {
             + 'static,
         C::Future: Send + 'static,
         C::Error: Into<tower::BoxError>,
-        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + 'static,
-        B::Error: Into<tower::BoxError>,
+        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + Unpin + 'static,
+        B::Error: Into<tower::BoxError> + Send + Sync,
     {
         self.build_inner(move |client_args| client_args.try_from_service(client))
             .await
@@ -240,8 +240,8 @@ impl Builder<ServerArgs> {
             + 'static,
         C::Future: Send + 'static,
         C::Error: Into<tower::BoxError>,
-        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + 'static,
-        B::Error: Into<tower::BoxError>,
+        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + Unpin + 'static,
+        B::Error: Into<tower::BoxError> + Send + Sync,
     {
         let rt = self
             .build_inner(move |client_args| client_args.try_from_service(client))
@@ -298,8 +298,8 @@ impl Builder<Option<ServerArgs>> {
             + 'static,
         C::Future: Send + 'static,
         C::Error: Into<tower::BoxError>,
-        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + 'static,
-        B::Error: Into<tower::BoxError>,
+        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + Unpin + 'static,
+        B::Error: Into<tower::BoxError> + Send + Sync,
     {
         let rt = self
             .build_inner(move |client_args| client_args.try_from_service(client))

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -8,7 +8,7 @@ use std::{convert::Infallible, net::SocketAddr, path::PathBuf, str::FromStr, syn
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{rustls, TlsAcceptor};
-use tower_service::Service;
+use tower::Service;
 use tracing::{debug, error, info, info_span, Instrument};
 
 /// Command-line arguments used to configure a server


### PR DESCRIPTION
Currently, Kubert's `Runtime` will always construct a Kubernetes client
by using the `TryInto<Client> for kube_client::client::Config`. This
will construct a client with a Hyper `HttpConnector` which is
constructed by `kube-client`. In some cases, it may be desirable to
provide a custom HTTP client, such as when using an alternative TLS
implementation to those supported by `kube-client`.

This branch adds support for providing an alternative `tower::Service`
for the client used by  `kubert`'s `Runtime`. When using a custom client
`Service`, the Kubernetes client stack is still configured from the
provided `ClientArgs`, but the underlying HTTP connection is provided by
the user `Service`.