### PR TITLE
chore: allow some duplicate deps

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -73,8 +73,8 @@ skip-tree = [
     # 1.0 to `syn` 2.0
     { name = "syn" },
     # `parking-lot-core` and `dirs-next` (transitive deps via `kube-client`)
-    # depend on incompatible versions of `redox-syscall`.
-    { name = "redox-syscall" },
+    # depend on incompatible versions of `redox_syscall`.
+    { name = "redox_syscall" },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -67,11 +67,14 @@ skip-tree = [
     # libraries.
     # TODO(eliza): remove this skip when the conflicts are resolved.
     { name = "metrics-process" },
-    # serde_json and serde_yaml depend on incompatible versions of indexmap
+    # `serde_json` and `serde_yaml` depend on incompatible versions of indexmap
     { name = "indexmap" },
     # the proc-macro ecosystem is still in the process of migrating from `syn`
     # 1.0 to `syn` 2.0
     { name = "syn" },
+    # `parking-lot-core` and `dirs-next` (transitive deps via `kube-client`)
+    # depend on incompatible versions of `redox-syscall`.
+    { name = "redox-syscall" },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -66,7 +66,12 @@ skip-tree = [
     # are incompatible with the transitive deps other crates have on those
     # libraries.
     # TODO(eliza): remove this skip when the conflicts are resolved.
-    { name = "metrics-process" }
+    { name = "metrics-process" },
+    # serde_json and serde_yaml depend on incompatible versions of indexmap
+    { name = "indexmap" },
+    # the proc-macro ecosystem is still in the process of migrating from `syn`
+    # 1.0 to `syn` 2.0
+    { name = "syn" },
 ]
 
 [sources]


### PR DESCRIPTION
This branch allows duplicate dependencies on the following crates:

* `indexmap`, because the versions of `serde_json` and `serde_yaml` currently pulled by our `kube-core` dependency require incompatible `indexmap` versions. We ignore `indexmap`'s whole dep tree, because the incompatible `indexmap` versions also depend on incompatible versions of `hashbrown`.

* `syn`, because the proc-macro ecosystem is still in the process of updating from `syn` v1 to `syn` v2.

This should fix the CI build.