### PR TITLE
chore: bump `kube` deps to v0.84

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -31,7 +31,7 @@ default-features = false
 features = ["v1_26"]
 
 [dev-dependencies.kube]
-version = "0.83"
+version = "0.84"
 default-features = false
 features = ["client", "derive", "openssl-tls", "runtime"]
 

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -152,18 +152,18 @@ optional = true
 default-features = false
 
 [dependencies.kube-client]
-version = "0.83"
+version = "0.84"
 optional = true
 default-features = false
 features = ["client", "config"]
 
 [dependencies.kube-core]
-version = "0.83"
+version = "0.84"
 optional = true
 default-features = false
 
 [dependencies.kube-runtime]
-version = "0.83"
+version = "0.84"
 optional = true
 default-features = false
 
@@ -176,7 +176,7 @@ features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"]
 # === Dev ===
 
 [dev-dependencies]
-kube = { version = "0.83", default-features = false, features = ["runtime"] }
+kube = { version = "0.84", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }


### PR DESCRIPTION
This will hopefully let us eliminate some mismatched Rustls versions.