### PR TITLE
Fix compilation when only the `lease` feature is enabled

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -49,6 +49,7 @@ initialized = ["futures-core", "futures-util", "pin-project-lite", "tokio/sync"]
 lease = [
     "backoff",
     "chrono",
+    "futures-util",
     "hyper",
     "k8s-openapi",
     "kube-client",


### PR DESCRIPTION
Compilation fails when the consumer of the kubert library has disabled all the default features and has enabled only the `lease` one.

The compilation fails because `lease.rs` uses `futures_util::TryFutureExt` but the `features-utils` library is not part of the dependencies.
