### PR TITLE
chore: update `boringssl` deps to v3.x

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -78,9 +78,6 @@ skip-tree = [
     # `parking-lot-core` and `dirs-next` (transitive deps via `kube-client`)
     # depend on incompatible versions of `redox_syscall`.
     { name = "redox_syscall" },
-    # the current versions of `openssl` and `boring` depend on versions 0.3 and
-    # 0.5 of `foreign-types` and `foreign-types-shared`, respectively.
-    { name = "foreign-types" },
 ]
 
 [sources]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -125,7 +125,7 @@ features = ["k8s-openapi/v1_26"]
 [dependencies]
 ahash = { version = "0.8", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
-boring = { version = "2.1.0", optional = true }
+boring = { version = "3.0.4", optional = true }
 bytes = { version = "1", optional = true }
 deflate = { version = "1", optional = true, default-features = false, features = [
     "gzip",
@@ -135,7 +135,7 @@ chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
-hyper-boring = { version = "2", optional = true }
+hyper-boring = { version = "3.0.4", optional = true }
 metrics-exporter-prometheus = { version = "0.12.0", optional = true, default-features = false }
 metrics-process = { version = "1.0.11", optional = true }
 once_cell = { version = "1", optional = true }
@@ -146,7 +146,7 @@ thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }
-tokio-boring = { version = "2.1.5", optional = true }
+tokio-boring = { version = "3.0.4", optional = true }
 tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.24.1", optional = true, default-features = false }
 tower-http = { version = "0.4.0", optional = true, default-features = false, features = ["map-response-body"] }


### PR DESCRIPTION
This branch updates the dependencies on `boring`, `tokio-boring`, and `hyper-boring` to v3.0.0. This dependency update does not appear to contain any breaking changes to the APIs currently used by Kubert, so the only reason this dependency bump had to be performed manually is because the `tokio-boring` and `hyper-boring` deps depend on `boring`, so the three crates must have their versions bumped atomically.

Because `boring-sys` v3.0 updates its dependency on `foreign-types` to the same major as `openssl-sys`, we no longer need to allow multiple versions of that crate in `deny.toml`.

Closes #174
Closes #175
Closes #176