### PR TITLE
update to `kube-rs` v0.85 and `k8s-openapi` v0.19

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,12 +26,12 @@ default-features = false
 features = ["derive", "help", "env", "std"]
 
 [dev-dependencies.k8s-openapi]
-version = "0.18"
+version = "0.19"
 default-features = false
-features = ["v1_26"]
+features = ["v1_27"]
 
 [dev-dependencies.kube]
-version = "0.84"
+version = "0.85"
 default-features = false
 features = ["client", "derive", "rustls-tls", "runtime"]
 

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."
@@ -120,7 +120,7 @@ shutdown = [
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
-features = ["k8s-openapi/v1_26"]
+features = ["k8s-openapi/v1_27"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
@@ -164,23 +164,23 @@ features = ["derive", "std"]
 # Not used directly, but required to ensure that the k8s-openapi dependency is considered part of
 # the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.18"
+version = "0.19"
 optional = true
 default-features = false
 
 [dependencies.kube-client]
-version = "0.84"
+version = "0.85"
 optional = true
 default-features = false
 features = ["client", "config"]
 
 [dependencies.kube-core]
-version = "0.84"
+version = "0.85"
 optional = true
 default-features = false
 
 [dependencies.kube-runtime]
-version = "0.84"
+version = "0.85"
 optional = true
 default-features = false
 
@@ -193,15 +193,15 @@ features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"]
 # === Dev ===
 
 [dev-dependencies]
-kube = { version = "0.84", default-features = false, features = ["runtime"] }
+kube = { version = "0.85", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
 
 [dev-dependencies.k8s-openapi]
-version = "0.18"
+version = "0.19"
 default-features = false
-features = ["v1_26"]
+features = ["v1_27"]
 
 [dev-dependencies.tokio]
 version = "1.18"


### PR DESCRIPTION
This branch updates `kubert`'s dependencies on `kube-rs` to v0.85 and `k8s-openapi` to v0.19. This release of `k8s-openapi` adds support for Kubernetes v1.27.

I've also gone ahead and bumped `kubert`'s version to v0.18, since this is a breaking change.