### PR TITLE
server: Fix private key parsing with BoringSSL

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -25,6 +25,10 @@ jobs:
         k8s:
           - v1.21
           - v1.26
+        tls:
+          - "boring-tls"
+          - "rustls-tls"
+    name: "local (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
@@ -34,17 +38,19 @@ jobs:
       - uses: linkerd/dev/actions/setup-rust@v40
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - run: just fetch
-      - run: just build-examples
-      - run: just test-cluster-create
-      - run: just test-cluster-run-watch-pods --log-level=debug
-      - run: just test-cluster-create-ns
+      - run: just --set features ${{ matrix.tls }} build-examples
+      - run: just --set features ${{ matrix.tls }} test-cluster-create
+      - run: just --set features ${{ matrix.tls }} test-cluster-run-watch-pods --log-level=debug
+      - run: just --set features ${{ matrix.tls }} test-cluster-create-ns
       - name: Run just test-cluster-run-watch-pods with impersonation
         run: |
-          just test-cluster-run-watch-pods --log-level=debug \
+          just --set features ${{ matrix.tls }} \
+            test-cluster-run-watch-pods \
+            --log-level=debug \
             --as=system:serviceaccount:${KUBERT_TEST_NS}:watch-pods \
             --kubeconfig=$HOME/.kube/config
-      - run: just test-lease-build
-      - run: just test-lease
+      - run: just --set features ${{ matrix.tls }} test-lease-build
+      - run: just --set features ${{ matrix.tls }} test-lease
 
   in-cluster:
     strategy:
@@ -52,6 +58,10 @@ jobs:
         k8s:
           - v1.21
           - v1.26
+        tls:
+          - "boring-tls"
+          - "rustls-tls"
+    name: "in-cluster (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
@@ -61,8 +71,8 @@ jobs:
       - uses: linkerd/dev/actions/setup-tools@v40
       - uses: linkerd/dev/actions/setup-rust@v40
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      - run: just build-examples-image
-      - run: just test-cluster-create
-      - run: just test-cluster-import-examples
-      - run: just test-cluster-create-ns
-      - run: just test-cluster-deploy-watch-pods --log-level=debug
+      - run: just --set features ${{ matrix.tls }} build-examples-image
+      - run: just --set features ${{ matrix.tls }} test-cluster-create
+      - run: just --set features ${{ matrix.tls }} test-cluster-import-examples
+      - run: just --set features ${{ matrix.tls }} test-cluster-create-ns
+      - run: just --set features ${{ matrix.tls }} test-cluster-deploy-watch-pods --log-level=debug

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,10 @@ skip-tree = [
     # `parking-lot-core` and `dirs-next` (transitive deps via `kube-client`)
     # depend on incompatible versions of `redox_syscall`.
     { name = "redox_syscall" },
+    # `rcgen` depends on a significantly diverged version of the `pem` crate
+    # from `kube-client` (v3.0 vs v1.1). however, since `rcgen` is a test-only
+    # dependency, this isn't a huge deal, and we can ignore it.
+    { name = "rcgen" },
 ]
 
 [sources]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,16 @@ rust-version = "1.60"
 [package.metadata.release]
 release = false
 
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["kubert/rustls-tls"]
+boring-tls = ["kubert/boring-tls"]
+
+[dependencies.kubert]
+path = "../kubert"
+default-features = false
+features = ["clap", "lease", "runtime", ]
+
 [dev-dependencies]
 anyhow = "1"
 chrono = { version = "0.4", default-features = false }
@@ -34,11 +44,6 @@ features = ["v1_27"]
 version = "0.85"
 default-features = false
 features = ["client", "derive", "rustls-tls", "runtime"]
-
-[dev-dependencies.kubert]
-path = "../kubert"
-default-features = false
-features = ["clap", "lease", "runtime", "rustls-tls"]
 
 [dev-dependencies.tokio]
 version = "1"

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,10 +1,14 @@
+
+ARG FEATURES="rustls-tls"
 FROM ghcr.io/linkerd/dev:v40-rust as build
 WORKDIR /kubert
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     CARGO_NET_RETRY=10 just-cargo fetch
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    CARGO_INCREMENTAL=0 just-cargo build --frozen --package=kubert-examples --examples
+    CARGO_INCREMENTAL=0 just-cargo build \
+    --frozen --package=kubert-examples --examples \
+    --no-default-features --features=${FEATURES}
 
 FROM gcr.io/distroless/cc
 COPY --from=build /kubert/target/debug/examples/watch-pods /watch-pods

--- a/justfile
+++ b/justfile
@@ -55,10 +55,13 @@ build *args:
 
 build-examples name='':
     @just-cargo build --package=kubert-examples \
-        {{ if name == '' { "--examples" } else { "--example=" + name } }}
+        {{ if name == '' { "--examples" } else { "--example=" + name } }} \
+        {{ _features }}
 
 build-examples-image:
-    docker buildx build . -f examples/Dockerfile --tag=kubert-examples:test --output=type=docker
+    docker buildx build . -f examples/Dockerfile \
+        --tag=kubert-examples:test --output=type=docker \
+        {{ if features != "all" { "--build-arg='FEATURES={{ features }}'" } else { "" } }}
 
 test-cluster-create:
     #!/usr/bin/env bash

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -17,9 +17,13 @@ rustls-tls = [
 ]
 boring-tls = [
     "boring",
+    "base64",
     "hyper-boring",
     "tokio-boring",
     "once_cell",
+    "serde",
+    "serde_json",
+    "secrecy",
 ]
 admin = [
     "ahash",
@@ -125,6 +129,7 @@ features = ["k8s-openapi/v1_27"]
 [dependencies]
 ahash = { version = "0.8", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
+base64 = { version = "0.21", optional = true }
 boring = { version = "3.0.4", optional = true }
 bytes = { version = "1", optional = true }
 deflate = { version = "1", optional = true, default-features = false, features = [
@@ -143,6 +148,7 @@ parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
+secrecy = { version = "0.8", optional = true, features = ["alloc", "serde"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -197,7 +197,9 @@ kube = { version = "0.85", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
+# used for generating TLS certificates in the server tests.
 rcgen = { version = "0.11.2" }
+# used for creating temporary dirs for TLS certificates in the server tests.
 tempfile = "3.8"
 
 [dev-dependencies.k8s-openapi]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -197,6 +197,8 @@ kube = { version = "0.85", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
+rcgen = { version = "0.11.2" }
+tempfile = "3.8"
 
 [dev-dependencies.k8s-openapi]
 version = "0.19"

--- a/kubert/src/client/tls_boring.rs
+++ b/kubert/src/client/tls_boring.rs
@@ -1,0 +1,355 @@
+use boring::{
+    error::ErrorStack,
+    pkey::PKey,
+    ssl::{SslConnector, SslConnectorBuilder, SslMethod},
+    x509::X509,
+};
+use hyper_boring::HttpsConnector;
+use kube_client::config::{AuthInfo, Config};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Errors from BoringSSL TLS
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// Failed to create BoringSSL HTTPS connector
+    #[error("failed to create BoringSSL HTTPS connector: {0}")]
+    CreateHttpsConnector(#[source] ErrorStack),
+
+    /// Failed to build SslConnectorBuilder
+    #[error("failed to build BoringSSL SslConnectorBuilder: {0}")]
+    CreateBuilder(#[source] ErrorStack),
+
+    /// Failed to deserialize PEM-encoded chain of certificates
+    #[error("failed to deserialize PEM-encoded chain of certificates: {0}")]
+    DeserializeCertificateChain(#[source] ErrorStack),
+
+    /// Failed to deserialize PEM-encoded private key
+    #[error("failed to deserialize PEM-encoded private key: {0}")]
+    DeserializePrivateKey(#[source] ErrorStack),
+
+    /// Failed to set private key
+    #[error("failed to set private key: {0}")]
+    SetPrivateKey(#[source] ErrorStack),
+
+    /// Failed to get a leaf certificate, the certificate chain is empty
+    #[error("failed to get a leaf certificate, the certificate chain is empty")]
+    GetLeafCertificate,
+
+    /// Failed to set the leaf certificate
+    #[error("failed to set the leaf certificate: {0}")]
+    SetLeafCertificate(#[source] ErrorStack),
+
+    /// Failed to append a certificate to the chain
+    #[error("failed to append a certificate to the chain: {0}")]
+    AppendCertificate(#[source] ErrorStack),
+
+    /// Failed to deserialize DER-encoded root certificate
+    #[error("failed to deserialize DER-encoded root certificate: {0}")]
+    DeserializeRootCertificate(#[source] ErrorStack),
+
+    /// Failed to add a root certificate
+    #[error("failed to add a root certificate: {0}")]
+    AddRootCertificate(#[source] ErrorStack),
+
+    /// Failed to load client certificate from kubeconfig
+    #[error("failed to load client certificate: {0}")]
+    LoadClientCertificate(#[source] LoadDataError),
+
+    /// Failed to load client key from kubeconfig
+    #[error("failed to load client key: {0}")]
+    LoadClientKey(#[source] LoadDataError),
+}
+
+/// Errors from loading data from a base64 string or a file
+#[derive(Debug, Error)]
+pub enum LoadDataError {
+    /// Failed to decode base64 data
+    #[error("failed to decode base64 data: {0}")]
+    DecodeBase64(#[source] base64::DecodeError),
+
+    /// Failed to read file
+    #[error("failed to read file '{1:?}': {0}")]
+    ReadFile(#[source] std::io::Error, PathBuf),
+
+    /// No base64 data or file path was provided
+    #[error("no base64 data or file")]
+    NoBase64DataOrFile,
+}
+
+pub(crate) fn https_connector(
+    cfg: &Config,
+) -> Result<HttpsConnector<hyper::client::HttpConnector>, Error> {
+    let mut connector = hyper::client::HttpConnector::new();
+    connector.enforce_http(false);
+    let identity = identity_pem(&cfg.auth_info)?;
+    let builder = ssl_connector_builder(identity.as_ref(), cfg.root_cert.as_ref())?;
+    let mut https =
+        HttpsConnector::with_connector(connector, builder).map_err(Error::CreateHttpsConnector)?;
+    if cfg.accept_invalid_certs {
+        https.set_callback(|ssl, _uri| {
+            ssl.set_verify(boring::ssl::SslVerifyMode::NONE);
+            Ok(())
+        });
+    }
+    Ok(https)
+}
+
+/// Create `boring::ssl::SslConnectorBuilder` required for `hyper_boring::HttpsConnector`.
+fn ssl_connector_builder(
+    identity_pem: Option<&Vec<u8>>,
+    root_certs: Option<&Vec<Vec<u8>>>,
+) -> Result<SslConnectorBuilder, Error> {
+    let mut builder = SslConnector::builder(SslMethod::tls()).map_err(Error::CreateBuilder)?;
+    if let Some(pem) = identity_pem {
+        let mut chain = X509::stack_from_pem(pem)
+            .map_err(Error::DeserializeCertificateChain)?
+            .into_iter();
+        let leaf_cert = chain.next().ok_or(Error::GetLeafCertificate)?;
+        builder
+            .set_certificate(&leaf_cert)
+            .map_err(Error::SetLeafCertificate)?;
+        for cert in chain {
+            builder
+                .add_extra_chain_cert(cert)
+                .map_err(Error::AppendCertificate)?;
+        }
+
+        let pkey = PKey::private_key_from_pem(pem).map_err(Error::DeserializePrivateKey)?;
+        builder
+            .set_private_key(&pkey)
+            .map_err(Error::SetPrivateKey)?;
+    }
+
+    if let Some(ders) = root_certs {
+        for der in ders {
+            let cert = X509::from_der(der).map_err(Error::DeserializeRootCertificate)?;
+            builder
+                .cert_store_mut()
+                .add_cert(cert)
+                .map_err(Error::AddRootCertificate)?;
+        }
+    }
+
+    Ok(builder)
+}
+
+fn identity_pem(cfg: &AuthInfo) -> Result<Option<Vec<u8>>, Error> {
+    use secrecy::ExposeSecret;
+    use std::fs;
+
+    fn load_from_base64_or_file<P: AsRef<Path>>(
+        value: Option<&str>,
+        file: Option<P>,
+    ) -> Result<Vec<u8>, LoadDataError> {
+        fn load_from_base64(value: &str) -> Result<Vec<u8>, LoadDataError> {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD_NO_PAD
+                .decode(value)
+                .map_err(LoadDataError::DecodeBase64)
+        }
+
+        fn load_from_file<P: AsRef<Path>>(file: &P) -> Result<Vec<u8>, LoadDataError> {
+            fs::read(file).map_err(|source| LoadDataError::ReadFile(source, file.as_ref().into()))
+        }
+
+        // Ensure there is a trailing newline in the blob
+        // Don't bother if the blob is empty
+        fn ensure_trailing_newline(mut data: Vec<u8>) -> Vec<u8> {
+            if data.last().map(|end| *end != b'\n').unwrap_or(false) {
+                data.push(b'\n');
+            }
+            data
+        }
+
+        let data = value
+            .map(load_from_base64)
+            .or_else(|| file.as_ref().map(load_from_file))
+            .unwrap_or_else(|| Err(LoadDataError::NoBase64DataOrFile))?;
+        Ok(ensure_trailing_newline(data))
+    }
+
+    if let Some(exec_pem) = cfg.exec.as_ref().and_then(auth_plugin_identity_pem) {
+        return Ok(Some(exec_pem));
+    }
+
+    // no client cert *and* no client key is not an error --- if one or the
+    // other is missing, that's an error.
+    if cfg.client_certificate_data.is_none()
+        && cfg.client_certificate.is_none()
+        && cfg.client_key_data.is_none()
+        && cfg.client_key.is_none()
+    {
+        return Ok(None);
+    }
+
+    let client_cert = load_from_base64_or_file(
+        cfg.client_certificate_data.as_deref(),
+        cfg.client_certificate,
+    )
+    .map_err(Error::LoadClientCertificate)?;
+
+    let client_key = {
+        let data = cfg
+            .client_key_data
+            .as_ref()
+            .map(|secret| secret.expose_secret().as_str());
+        load_from_base64_or_file(data, cfg.client_key).map_err(Error::LoadClientKey)?
+    };
+
+    Ok(Some(make_identity_pem(client_cert, client_key)))
+}
+
+// This is necessary to retrieve an identity when an exec plugin
+// returns a client certificate and key instead of a token.
+// This has be to be checked on TLS configuration vs tokens
+// which can be added in as an AuthLayer.
+fn auth_plugin_identity_pem(auth: &kube_client::config::ExecConfig) -> Option<Vec<u8>> {
+    use kube_client::config::ExecInteractiveMode;
+    use serde::{Deserialize, Serialize};
+    use std::process::{Command, Stdio};
+    /// ExecCredentials is used by exec-based plugins to communicate credentials to
+    /// HTTP transports.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct ExecCredential {
+        kind: Option<String>,
+        #[serde(rename = "apiVersion")]
+        api_version: Option<String>,
+        spec: Option<ExecCredentialSpec>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status: Option<ExecCredentialStatus>,
+    }
+
+    /// ExecCredenitalSpec holds request and runtime specific information provided
+    /// by transport.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct ExecCredentialSpec {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        interactive: Option<bool>,
+    }
+
+    /// ExecCredentialStatus holds credentials for the transport to use.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct ExecCredentialStatus {
+        #[serde(rename = "expirationTimestamp")]
+        expiration_timestamp: Option<String>,
+        token: Option<String>,
+        #[serde(rename = "clientCertificateData")]
+        client_certificate_data: Option<String>,
+        #[serde(rename = "clientKeyData")]
+        client_key_data: Option<String>,
+    }
+
+    let mut cmd = Command::new(&auth.command?);
+    if let Some(args) = &auth.args {
+        cmd.args(args);
+    }
+    if let Some(env) = &auth.env {
+        let envs = env
+            .iter()
+            .flat_map(|env| match (env.get("name"), env.get("value")) {
+                (Some(name), Some(value)) => Some((name, value)),
+                _ => None,
+            });
+        cmd.envs(envs);
+    }
+
+    let interactive = auth.interactive_mode != Some(ExecInteractiveMode::Never);
+    if interactive {
+        cmd.stdin(Stdio::inherit());
+    } else {
+        cmd.stdin(Stdio::piped());
+    }
+
+    // Provide exec info to child process
+    let exec_info = {
+        let info = ExecCredential {
+            api_version: auth.api_version.clone(),
+            kind: None,
+            spec: Some(ExecCredentialSpec {
+                interactive: Some(interactive),
+            }),
+            status: None,
+        };
+        match serde_json::to_string(&info) {
+            Ok(i) => i,
+            Err(error) => {
+                tracing::error!(%error, ?info, "failed to serialize exec info");
+                return None;
+            }
+        }
+    };
+
+    cmd.env("KUBERNETES_EXEC_INFO", exec_info);
+
+    if let Some(envs) = &auth.drop_env {
+        for env in envs {
+            cmd.env_remove(env);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let out = match cmd.output() {
+        Ok(out) if !out.status.success() => {
+            tracing::error!(?cmd, status = ?out.status, "failed to execute auth plugin");
+            return None;
+        }
+        Err(error) => {
+            tracing::error!(?cmd, %error, "failed to execute auth plugin");
+            return None;
+        }
+        Ok(out) => out,
+    };
+
+    let creds: ExecCredential = match serde_json::from_slice(&out.stdout) {
+        Err(error) => {
+            tracing::error!(
+                ?error,
+                output = ?String::from_utf8_lossy(&out.stdout[..]),
+                "failed to parse auth plugin output as JSON",
+            );
+            return None;
+        }
+        Ok(creds) => creds,
+    };
+
+    let status = match creds.status {
+        None => {
+            tracing::error!(
+                output = ?creds,
+                "auth plugin did not return credentials",
+            );
+            return None;
+        }
+        Some(status) => status,
+    };
+
+    match (status.client_certificate_data, status.client_key_data) {
+        (None, None) => None,
+        (Some(_), None) => {
+            tracing::warn!("missing client key data from auth plugin");
+            None
+        }
+        (None, Some(_)) => {
+            tracing::warn!("missing client certificate data from auth plugin");
+            None
+        }
+        (Some(cert), Some(key)) => Some(make_identity_pem(cert.into_bytes(), key)),
+    }
+}
+
+fn make_identity_pem(cert: Vec<u8>, key: impl AsRef<[u8]>) -> Vec<u8> {
+    let key = key.as_ref();
+    let mut buf = cert;
+    buf.reserve(key.len() + 2);
+    buf.push(b'\n');
+    buf.extend_from_slice(key);
+    buf.push(b'\n');
+    buf
+}

--- a/kubert/src/client/tls_boring.rs
+++ b/kubert/src/client/tls_boring.rs
@@ -186,7 +186,7 @@ fn identity_pem(cfg: &AuthInfo) -> Result<Option<Vec<u8>>, Error> {
 
     let client_cert = load_from_base64_or_file(
         cfg.client_certificate_data.as_deref(),
-        cfg.client_certificate,
+        cfg.client_certificate.as_ref(),
     )
     .map_err(Error::LoadClientCertificate)?;
 
@@ -195,7 +195,7 @@ fn identity_pem(cfg: &AuthInfo) -> Result<Option<Vec<u8>>, Error> {
             .client_key_data
             .as_ref()
             .map(|secret| secret.expose_secret().as_str());
-        load_from_base64_or_file(data, cfg.client_key).map_err(Error::LoadClientKey)?
+        load_from_base64_or_file(data, cfg.client_key.as_ref()).map_err(Error::LoadClientKey)?
     };
 
     Ok(Some(make_identity_pem(client_cert, client_key)))
@@ -241,7 +241,7 @@ fn auth_plugin_identity_pem(auth: &kube_client::config::ExecConfig) -> Option<Ve
         client_key_data: Option<String>,
     }
 
-    let mut cmd = Command::new(&auth.command?);
+    let mut cmd = Command::new(auth.command.as_deref()?);
     if let Some(args) = &auth.args {
         cmd.args(args);
     }

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -28,6 +28,9 @@ mod tls;
 #[path = "./server/tls_boring.rs"]
 mod tls;
 
+#[cfg(all(test, any(feature = "rustls-tls", feature = "boring-tls")))]
+mod tests;
+
 #[cfg(not(any(feature = "rustls-tls", feature = "boring-tls")))]
 mod tls {
     use super::*;

--- a/kubert/src/server/tests.rs
+++ b/kubert/src/server/tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+use tempfile::TempDir;
+
+fn gen_keys() -> (TempDir, TlsPaths) {
+    use std::{fs::File, io::Write};
+
+    let dir = TempDir::with_prefix("kubert-test").expect("failed to create temporary directory");
+
+    let cert = rcgen::generate_simple_self_signed(vec!["kubert.test.example.com".to_string()])
+        .expect("failed to generate certs");
+
+    let certs = {
+        let path = dir.path().join("cert.pem");
+        let mut file = File::create(&path).expect("failed to create cert file");
+        let pem = cert
+            .serialize_pem()
+            .expect("failed to serializez certs PEM");
+        file.write_all(pem.as_bytes())
+            .expect("failed to write certs PEM to tempfile");
+        TlsCertPath(path)
+    };
+
+    let key = {
+        let path = dir.path().join("key.pem");
+        let mut file = File::create(&path).expect("failed to create private key file");
+        let pem = cert.serialize_private_key_pem();
+        file.write_all(pem.as_bytes())
+            .expect("failed to write private key PEM to tempfile");
+        TlsKeyPath(path)
+    };
+
+    (dir, TlsPaths { key, certs })
+}
+
+#[tokio::test]
+async fn load_tls() {
+    let (_tempdir, TlsPaths { key, certs }) = gen_keys();
+    match super::tls::load_tls(&key, &certs).await {
+        Ok(_) => eprintln!("load_tls: success!"),
+        Err(error) => panic!("load_tls failed! {error}"),
+    }
+}

--- a/kubert/src/server/tls_boring.rs
+++ b/kubert/src/server/tls_boring.rs
@@ -94,6 +94,6 @@ impl TlsKeyPath {
         let pem = tokio::fs::read(&self.0).await?;
 
         // Load and return a single private key.
-        Ok(PKey::private_key_from_pkcs8(&pem)?)
+        Ok(PKey::private_key_from_pem(&pem)?)
     }
 }


### PR DESCRIPTION
Currently, the `tls_boring` module incorrectly passes a PEM-encoded
private key file to `boring::PKey::private_key_from_pkcs8`, which
expects a single DER-encoded PKCS#8 private key. This fails, because the
PEM file's contents is PEM-encoded, rather than DER-encoded. The test
added in 9187fb89e201062e80083f9ebd6532b39491f940 reproduces this
failure.

This PR changes the `tls_boring` module to use
`PKey::private_key_from_pem` instead of `PKey::private_key_from_pkcs8`,
which correctly parses the PEM-encoded private key file contents.

We _may_ wish to consider making this code smarter and determining the
input file format based on the filename extension, so that we can handle
private key files with different encodings. But, the `rustls`
implementation currently assumes that the private key file is always
PEM-encoded, so that's probably better saved for future work.