### PR TITLE
style: fix clippy warnings on `cfg` attributes

### DIFF
--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -111,19 +111,19 @@ pub mod shutdown;
 #[cfg(all(feature = "admin", feature = "clap"))]
 pub use self::admin::AdminArgs;
 
-#[cfg(all(feature = "client"))]
+#[cfg(feature = "client")]
 pub use self::client::ClientArgs;
 
-#[cfg(all(feature = "initialized"))]
+#[cfg(feature = "initialized")]
 pub use self::initialized::Initialized;
 
-#[cfg(all(feature = "lease"))]
+#[cfg(feature = "lease")]
 pub use self::lease::LeaseManager;
 
-#[cfg(all(feature = "log"))]
+#[cfg(feature = "log")]
 pub use self::log::{LogFilter, LogFormat, LogInitError};
 
-#[cfg(all(feature = "runtime"))]
+#[cfg(feature = "runtime")]
 pub use self::runtime::Runtime;
 
 #[cfg(feature = "server")]


### PR DESCRIPTION
Clippy doesn't like the use of `#[cfg(all(...))]` where there's only one condition in the `all(...)`. This commit fixes that and makes clippy happy about it.