### PR TITLE
temporarily pin `clap`  and `anstyle` dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,9 @@ chrono = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false }
 maplit = "1"
 rand = "0.8"
-regex = "1"
+# this is pinned to avoid a dep on `regex-syntax` v0.8.x, which requires Rust
+# >1.65 (where we only have 1.64).
+regex = "=1.9.6"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter"] }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -156,7 +156,7 @@ tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 [dependencies.clap]
-version = "4"
+version = "=4.3.24"
 optional = true
 default-features = false
 features = ["derive", "std"]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -124,6 +124,10 @@ features = ["k8s-openapi/v1_27"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
+# dependency of clap, which we must take an explicit dep on to ensure that it's
+# pinned to the version before the MSRV became incompatible with what's in the
+# devcontainer.
+anstyle = "=1.0.0"
 backoff = { version = "0.4", features = ["tokio"], optional = true }
 boring = { version = "3.0.4", optional = true }
 bytes = { version = "1", optional = true }
@@ -156,6 +160,8 @@ tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 [dependencies.clap]
+# temporarily pin to the version before the MSRV became 1.70, since Rust 1.70 is
+# newer than what's in our devcontainer.
 version = "=4.3.24"
 optional = true
 default-features = false

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -39,6 +39,11 @@ client = [
     "tower-http",
     "hyper",
 ]
+clap = [
+    "anstyle",
+    "clap_lex",
+    "dep:clap",
+]
 errors = [
     "futures-core",
     "futures-util",
@@ -127,7 +132,7 @@ ahash = { version = "0.8", optional = true }
 # dependency of clap, which we must take an explicit dep on to ensure that it's
 # pinned to the version before the MSRV became incompatible with what's in the
 # devcontainer.
-anstyle = "=1.0.0"
+anstyle = { version = "=1.0.0", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
 boring = { version = "3.0.4", optional = true }
 bytes = { version = "1", optional = true }
@@ -136,6 +141,10 @@ deflate = { version = "1", optional = true, default-features = false, features =
 ] }
 drain = { version = "0.1.1", optional = true, default-features = false }
 chrono = { version = "0.4", optional = true, default-features = false }
+# dependency of clap, which we must take an explicit dep on to ensure that it's
+# pinned to the version before the MSRV became incompatible with what's in the
+# devcontainer.
+clap_lex = { version = "=0.5.0", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }


### PR DESCRIPTION
This commit temporarily pins the `clap` dependency version to v4.3.24, since v4.4 changed Clap's MSRV to Rust 1.70, which our dev image doesn't have yet. It was also necessary to add an explicit dep on `anstyle`, a transitive dep via `clap`, so that we could pin that crate to v1.0.0, as v1.0.1 of `anstyle` also requires Rust 1.70.