### PR TITLE
replace BoringSSL with OpenSSL

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -26,9 +26,9 @@ jobs:
           - v1.21
           - v1.26
         tls:
-          - "openssl-tls"
-          - "rustls-tls"
-    name: "local (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
+          - openssl-tls
+          - rustls-tls
+    name: local (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -25,6 +25,10 @@ jobs:
         k8s:
           - v1.21
           - v1.26
+        tls:
+          - "openssl-tls"
+          - "rustls-tls"
+    name: "local (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
@@ -34,17 +38,19 @@ jobs:
       - uses: linkerd/dev/actions/setup-rust@v40
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - run: just fetch
-      - run: just build-examples
-      - run: just test-cluster-create
-      - run: just test-cluster-run-watch-pods --log-level=debug
-      - run: just test-cluster-create-ns
+      - run: just --set features ${{ matrix.tls }} build-examples
+      - run: just --set features ${{ matrix.tls }} test-cluster-create
+      - run: just --set features ${{ matrix.tls }} test-cluster-run-watch-pods --log-level=debug
+      - run: just --set features ${{ matrix.tls }} test-cluster-create-ns
       - name: Run just test-cluster-run-watch-pods with impersonation
         run: |
-          just test-cluster-run-watch-pods --log-level=debug \
+          just --set features ${{ matrix.tls }} \
+            test-cluster-run-watch-pods \
+            --log-level=debug \
             --as=system:serviceaccount:${KUBERT_TEST_NS}:watch-pods \
             --kubeconfig=$HOME/.kube/config
-      - run: just test-lease-build
-      - run: just test-lease
+      - run: just --set features ${{ matrix.tls }} test-lease-build
+      - run: just --set features ${{ matrix.tls }} test-lease
 
   in-cluster:
     strategy:
@@ -52,6 +58,10 @@ jobs:
         k8s:
           - v1.21
           - v1.26
+        tls:
+          - "openssl-tls"
+          - "rustls-tls"
+    name: "in-cluster (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
@@ -61,8 +71,8 @@ jobs:
       - uses: linkerd/dev/actions/setup-tools@v40
       - uses: linkerd/dev/actions/setup-rust@v40
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      - run: just build-examples-image
-      - run: just test-cluster-create
-      - run: just test-cluster-import-examples
-      - run: just test-cluster-create-ns
-      - run: just test-cluster-deploy-watch-pods --log-level=debug
+      - run: just --set features ${{ matrix.tls }} build-examples-image
+      - run: just --set features ${{ matrix.tls }} test-cluster-create
+      - run: just --set features ${{ matrix.tls }} test-cluster-import-examples
+      - run: just --set features ${{ matrix.tls }} test-cluster-create-ns
+      - run: just --set features ${{ matrix.tls }} test-cluster-deploy-watch-pods --log-level=debug

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -29,7 +29,7 @@ jobs:
           - openssl-tls
           - rustls-tls
     name: local (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})
-    timeout-minutes: 15
+    timeout-minutes: 30 # building with OpenSSL can be quite slow...
     runs-on: ubuntu-latest
     env:
       KUBERT_TEST_CLUSTER_VERSION: ${{ matrix.k8s }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -62,7 +62,7 @@ jobs:
           - "openssl-tls"
           - "rustls-tls"
     name: "in-cluster (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -59,9 +59,9 @@ jobs:
           - v1.21
           - v1.26
         tls:
-          - "openssl-tls"
-          - "rustls-tls"
-    name: "in-cluster (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})"
+          - openssl-tls
+          - rustls-tls
+    name: in-cluster (k8s ${{ matrix.k8s }}, ${{ matrix.tls }})
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - run: just fmt-check
 
   doc:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     container: ghcr.io/linkerd/dev:v40-rust
     steps:

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,12 @@ skip-tree = [
     # `parking-lot-core` and `dirs-next` (transitive deps via `kube-client`)
     # depend on incompatible versions of `redox_syscall`.
     { name = "redox_syscall" },
+    # `rcgen` (used to generate test key material in TLS server tests) depends
+    # on a version of the `pem` crate that has diverged substantially from
+    # `kube-client`'s dep on the same crate (v3.0 vs v1.1). however, since
+    # `rcgen` is a test-only dependency, it's not a huge deal if it introduces
+    # duplicate deps, as they won't be present in real life.
+    { name = "rcgen" },
 ]
 
 [sources]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,21 @@ rust-version = "1.60"
 [package.metadata.release]
 release = false
 
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["kubert/rustls-tls"]
+openssl-tls = ["kubert/openssl-tls", "openssl"]
+
+[dependencies.kubert]
+path = "../kubert"
+default-features = false
+features = ["clap", "lease", "runtime", ]
+
+[dependencies.openssl]
+version = "0.10.57"
+optional = true
+features = ["vendored"]
+
 [dev-dependencies]
 anyhow = "1"
 chrono = { version = "0.4", default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,9 @@ chrono = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false }
 maplit = "1"
 rand = "0.8"
-regex = "1"
+# this is pinned to avoid a dep on `regex-syntax` v0.8.x, which requires Rust
+# >1.65 (where we only have 1.64).
+regex = "=1.9.6"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ openssl-tls = ["kubert/openssl-tls", "openssl"]
 [dependencies.kubert]
 path = "../kubert"
 default-features = false
-features = ["clap", "lease", "runtime", ]
+features = ["clap", "lease", "runtime"]
 
 [dependencies.openssl]
 version = "0.10.57"
@@ -51,11 +51,6 @@ features = ["v1_27"]
 version = "0.85"
 default-features = false
 features = ["client", "derive", "rustls-tls", "runtime"]
-
-[dev-dependencies.kubert]
-path = "../kubert"
-default-features = false
-features = ["clap", "lease", "runtime", "rustls-tls"]
 
 [dev-dependencies.tokio]
 version = "1"

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -3,8 +3,11 @@ WORKDIR /kubert
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     CARGO_NET_RETRY=10 just-cargo fetch
+ARG FEATURES="rustls-tls"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    CARGO_INCREMENTAL=0 just-cargo build --frozen --package=kubert-examples --examples
+    CARGO_INCREMENTAL=0 just-cargo build \
+    --frozen --package=kubert-examples --examples \
+    --no-default-features --features=${FEATURES}
 
 FROM gcr.io/distroless/cc
 COPY --from=build /kubert/target/debug/examples/watch-pods /watch-pods

--- a/justfile
+++ b/justfile
@@ -55,10 +55,13 @@ build *args:
 
 build-examples name='':
     @just-cargo build --package=kubert-examples \
-        {{ if name == '' { "--examples" } else { "--example=" + name } }}
+        {{ if name == '' { "--examples" } else { "--example=" + name } }} \
+        {{ _features }}
 
 build-examples-image:
-    docker buildx build . -f examples/Dockerfile --tag=kubert-examples:test --output=type=docker
+    docker buildx build . -f examples/Dockerfile \
+        --tag=kubert-examples:test --output=type=docker \
+        {{ if features != "all" { "--build-arg='FEATURES={{ features }}'" } else { "" } }}
 
 test-cluster-create:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ build-examples name='':
 build-examples-image:
     docker buildx build . -f examples/Dockerfile \
         --tag=kubert-examples:test --output=type=docker \
-        {{ if features != "all" { "--build-arg='FEATURES={{ features }}'" } else { "" } }}
+        {{ if features != "all" { "--build-arg='FEATURES=" + features + "'" } else { "" } }}
 
 test-cluster-create:
     #!/usr/bin/env bash

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -15,11 +15,12 @@ rustls-tls = [
     "rustls-pemfile",
     "kube-client?/rustls-tls",
 ]
-boring-tls = [
-    "boring",
-    "hyper-boring",
-    "tokio-boring",
+openssl-tls = [
+    "openssl",
+    "hyper-openssl",
+    "tokio-openssl",
     "once_cell",
+    "kube-client?/openssl-tls",
 ]
 admin = [
     "ahash",
@@ -134,7 +135,7 @@ ahash = { version = "0.8", optional = true }
 # devcontainer.
 anstyle = { version = "=1.0.0", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
-boring = { version = "3.0.4", optional = true }
+openssl = { version = "0.10.57", optional = true, default-features = false }
 bytes = { version = "1", optional = true }
 deflate = { version = "1", optional = true, default-features = false, features = [
     "gzip",
@@ -148,7 +149,7 @@ clap_lex = { version = "=0.5.0", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
-hyper-boring = { version = "3.0.4", optional = true }
+hyper-openssl = { version = "0.9.2", optional = true }
 metrics-exporter-prometheus = { version = "0.12.0", optional = true, default-features = false }
 metrics-process = { version = "1.0.11", optional = true }
 once_cell = { version = "1", optional = true }
@@ -159,9 +160,9 @@ thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.17.0", optional = false, default-features = false }
-tokio-boring = { version = "3.0.4", optional = true }
-tokio-util = { version = "0.7", optional = true, default-features = false }
 tokio-rustls = { version = "0.24.1", optional = true, default-features = false }
+tokio-openssl = { version = "0.6.3", optional = true }
+tokio-util = { version = "0.7", optional = true, default-features = false }
 tower-http = { version = "0.4.0", optional = true, default-features = false, features = [
     "map-response-body",
 ] }
@@ -212,6 +213,10 @@ kube = { version = "0.85", default-features = false, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
+# used for generating TLS certificates in the server tests.
+rcgen = { version = "0.11.2" }
+# used for creating temporary dirs for TLS certificates in the server tests.
+tempfile = "3.8"
 
 [dev-dependencies.k8s-openapi]
 version = "0.19"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -156,7 +156,7 @@ tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 [dependencies.clap]
-version = "4"
+version = "=4.3.24"
 optional = true
 default-features = false
 features = ["derive", "std"]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -124,6 +124,10 @@ features = ["k8s-openapi/v1_27"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
+# dependency of clap, which we must take an explicit dep on to ensure that it's
+# pinned to the version before the MSRV became incompatible with what's in the
+# devcontainer.
+anstyle = "=1.0.0"
 backoff = { version = "0.4", features = ["tokio"], optional = true }
 boring = { version = "3.0.4", optional = true }
 bytes = { version = "1", optional = true }
@@ -156,6 +160,8 @@ tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 [dependencies.clap]
+# temporarily pin to the version before the MSRV became 1.70, since Rust 1.70 is
+# newer than what's in our devcontainer.
 version = "=4.3.24"
 optional = true
 default-features = false

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -135,7 +135,6 @@ ahash = { version = "0.8", optional = true }
 # devcontainer.
 anstyle = { version = "=1.0.0", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
-openssl = { version = "0.10.57", optional = true, default-features = false }
 bytes = { version = "1", optional = true }
 deflate = { version = "1", optional = true, default-features = false, features = [
     "gzip",
@@ -153,6 +152,7 @@ hyper-openssl = { version = "0.9.2", optional = true }
 metrics-exporter-prometheus = { version = "0.12.0", optional = true, default-features = false }
 metrics-process = { version = "1.0.11", optional = true }
 once_cell = { version = "1", optional = true }
+openssl = { version = "0.10.57", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 rustls-pemfile = { version = "1", optional = true }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -39,6 +39,11 @@ client = [
     "tower-http",
     "hyper",
 ]
+clap = [
+    "anstyle",
+    "clap_lex",
+    "dep:clap",
+]
 errors = [
     "futures-core",
     "futures-util",
@@ -127,7 +132,7 @@ ahash = { version = "0.8", optional = true }
 # dependency of clap, which we must take an explicit dep on to ensure that it's
 # pinned to the version before the MSRV became incompatible with what's in the
 # devcontainer.
-anstyle = "=1.0.0"
+anstyle = { version = "=1.0.0", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
 boring = { version = "3.0.4", optional = true }
 bytes = { version = "1", optional = true }
@@ -136,6 +141,10 @@ deflate = { version = "1", optional = true, default-features = false, features =
 ] }
 drain = { version = "0.1.1", optional = true, default-features = false }
 chrono = { version = "0.4", optional = true, default-features = false }
+# dependency of clap, which we must take an explicit dep on to ensure that it's
+# pinned to the version before the MSRV became incompatible with what's in the
+# devcontainer.
+clap_lex = { version = "=0.5.0", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -46,10 +46,14 @@
 //! panic when starting the server.
 //!
 //! - **rustls-tls**: Use [`rustls`] as the TLS implementation.
-//! - **boring-tls**: Use [BoringSSL] (via the [`boring`] crate) as the TLS
+//! - **openssl-tls**: Use [OpenSSL] (via the [`openssl`] crate) as the TLS
 //!   implementation. This feature takes priority over the **rustls-tls**
-//!   feature flag. If both are enabled, BoringSSL will be used instead of
+//!   feature flag. If both are enabled, OpenSSL will be used instead of
 //!   Rustls.
+//!
+//! If the `client` feature flag is enabled, these features will also enable the
+//! corresponding feature flags on the [`kube-client`] crate, to configure which
+//! TLS implementation is used by the underlying Kubernetes API client.
 //!
 //! [`kube`]: https://github.com/kube-rs/kube-rs
 //! [Cargo features]: https://doc.rust-lang.org/cargo/reference/features.html
@@ -57,8 +61,8 @@
 //! [`clap::Parser`]: https://docs.rs/clap/4/clap/trait.Parser.html
 //! [`kube-client`]: https://crates.io/crates/kube-client
 //! [`rustls`]: https://crates.io/crates/rustls
-//! [BoringSSL]: https://github.com/google/boringssl
-//! [`boring`]: https://crates.io/crates/boring
+//! [OpenSSL]: https://www.openssl.org/
+//! [`openssl`]: https://crates.io/crates/openssl
 
 #![deny(warnings, rust_2018_idioms, missing_docs)]
 #![forbid(unsafe_code)]

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -14,6 +14,8 @@ use kube_core::{NamespaceResourceScope, Resource};
 use kube_runtime::{reflector, watcher};
 use serde::de::DeserializeOwned;
 use std::{fmt::Debug, future::Future, hash::Hash, time::Duration};
+#[cfg(feature = "server")]
+use tower::Service;
 
 pub use kube_client::Api;
 pub use reflector::Store;

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -14,7 +14,6 @@ use kube_core::{NamespaceResourceScope, Resource};
 use kube_runtime::{reflector, watcher};
 use serde::de::DeserializeOwned;
 use std::{fmt::Debug, future::Future, hash::Hash, time::Duration};
-use tower::Service;
 
 pub use kube_client::Api;
 pub use reflector::Store;

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -186,24 +186,6 @@ impl Builder<NoServer> {
     pub async fn build(self) -> Result<Runtime<NoServer>, BuildError> {
         self.build_inner(ClientArgs::try_client).await
     }
-
-    /// Attempts to build a runtime using the provided client [`Service`], by
-    /// initializing logs, configuring the client from CLI arguments,
-    /// registering signal handlers and binding an admin server
-    pub async fn build_with_client<C, B>(self, client: C) -> Result<Runtime<NoServer>, BuildError>
-    where
-        C: Service<hyper::Request<hyper::Body>, Response = hyper::Response<B>>
-            + Send
-            + Clone
-            + 'static,
-        C::Future: Send + 'static,
-        C::Error: Into<tower::BoxError>,
-        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + Unpin + 'static,
-        B::Error: Into<tower::BoxError> + Send + Sync,
-    {
-        self.build_inner(move |client_args| client_args.try_from_service(client))
-            .await
-    }
 }
 
 #[cfg(feature = "server")]
@@ -220,32 +202,6 @@ impl Builder<ServerArgs> {
             })
             .await
     }
-
-    /// Attempts to build a runtime using the provided client [`Service`], by
-    /// initializing logs, configuring the client from CLI arguments,
-    /// registering signal handlers and binding admin and HTTPS servers.
-    pub async fn build_with_client<C, B>(
-        self,
-        client: C,
-    ) -> Result<Runtime<server::Bound>, BuildError>
-    where
-        C: Service<hyper::Request<hyper::Body>, Response = hyper::Response<B>>
-            + Send
-            + Clone
-            + 'static,
-        C::Future: Send + 'static,
-        C::Error: Into<tower::BoxError>,
-        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + Unpin + 'static,
-        B::Error: Into<tower::BoxError> + Send + Sync,
-    {
-        self.build_inner(move |client_args| client_args.try_from_service(client))
-            .await?
-            .bind_server(|args| async move {
-                let srv = args.bind().await?;
-                Ok(srv)
-            })
-            .await
-    }
 }
 
 #[cfg(feature = "server")]
@@ -255,38 +211,6 @@ impl Builder<Option<ServerArgs>> {
     #[cfg_attr(docsrs, doc(cfg(all(features = "runtime", feature = "server"))))]
     pub async fn build(self) -> Result<Runtime<Option<server::Bound>>, BuildError> {
         self.build_inner(ClientArgs::try_client)
-            .await?
-            .bind_server(|args| async move {
-                match args {
-                    Some(args) => {
-                        let srv = args.bind().await?;
-                        Ok(Some(srv))
-                    }
-                    None => Ok(None),
-                }
-            })
-            .await
-    }
-
-    /// Attempts to build a runtime using the provided client [`Service`], by
-    /// initializing logs, configuring the client from CLI arguments,
-    /// registering signal handlers and binding admin and HTTPS servers.
-    #[cfg_attr(docsrs, doc(cfg(all(features = "runtime", feature = "server"))))]
-    pub async fn build_with_client<C, B>(
-        self,
-        client: C,
-    ) -> Result<Runtime<Option<server::Bound>>, BuildError>
-    where
-        C: Service<hyper::Request<hyper::Body>, Response = hyper::Response<B>>
-            + Send
-            + Clone
-            + 'static,
-        C::Future: Send + 'static,
-        C::Error: Into<tower::BoxError>,
-        B: hyper::body::HttpBody<Data = bytes::Bytes> + Send + Unpin + 'static,
-        B::Error: Into<tower::BoxError> + Send + Sync,
-    {
-        self.build_inner(move |client_args| client_args.try_from_service(client))
             .await?
             .bind_server(|args| async move {
                 match args {

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -55,7 +55,6 @@ mod tls {
 #[cfg(test)]
 mod tests;
 
-
 /// Command-line arguments used to configure a server
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -66,11 +66,17 @@ pub struct ServerArgs {
     #[cfg_attr(feature = "clap", clap(long, default_value = "0.0.0.0:443"))]
     pub server_addr: SocketAddr,
 
-    /// The path to the server's TLS key.
+    /// The path to the server's TLS key file.
+    ///
+    /// This should be a PEM-encoded file containing a single PKCS#8 or RSA
+    /// private key.
     #[cfg_attr(feature = "clap", clap(long))]
     pub server_tls_key: Option<TlsKeyPath>,
 
-    /// The path to the server's TLS certificate
+    /// The path to the server's TLS certificate file.
+    ///
+    /// This should be a PEM-encoded file containing at least one TLS end-entity
+    /// certificate.
     #[cfg_attr(feature = "clap", clap(long))]
     pub server_tls_certs: Option<TlsCertPath>,
 }

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -21,12 +21,14 @@ use tower::Service;
 use tracing::{debug, error, info, info_span, Instrument};
 
 #[cfg(all(feature = "rustls-tls", not(feature = "openssl-tls")))]
-#[path = "./server/tls_rustls.rs"]
-mod tls;
+mod tls_rustls;
+#[cfg(all(feature = "rustls-tls", not(feature = "openssl-tls")))]
+use tls_rustls as tls;
 
 #[cfg(feature = "openssl-tls")]
-#[path = "./server/tls_openssl.rs"]
-mod tls;
+mod tls_openssl;
+#[cfg(feature = "openssl-tls")]
+use tls_openssl as tls;
 
 #[cfg(not(any(feature = "rustls-tls", feature = "openssl-tls")))]
 mod tls {

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -39,17 +39,11 @@ mod tls {
     const PANIC_MESSAGE: &str = "using Kubert's `server` module requires one \
         of the \"rustls-tls\" or \"openssl-tls\" Cargo features to be enabled";
 
-    pub(super) async fn load_certs(
-        pk: &TlsKeyPath,
-        crts: &TlsCertPath,
-    ) -> Result<TlsAcceptor, Error> {
+    pub(super) async fn load_tls(_: &TlsKeyPath, _: &TlsCertPath) -> Result<TlsAcceptor, Error> {
         panic!("{PANIC_MESSAGE}")
     }
 
-    pub(super) async fn accept(
-        acceptor: &TlsAcceptor,
-        sock: TcpStream,
-    ) -> Result<TcpStream, std::io::Error> {
+    pub(super) async fn accept(_: &TlsAcceptor, _: TcpStream) -> Result<TcpStream, std::io::Error> {
         panic!("{PANIC_MESSAGE}")
     }
 }

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -20,22 +20,22 @@ use tokio::net::{TcpListener, TcpStream};
 use tower::Service;
 use tracing::{debug, error, info, info_span, Instrument};
 
-#[cfg(all(feature = "rustls-tls", not(feature = "boring-tls")))]
+#[cfg(all(feature = "rustls-tls", not(feature = "openssl-tls")))]
 #[path = "./server/tls_rustls.rs"]
 mod tls;
 
-#[cfg(feature = "boring-tls")]
-#[path = "./server/tls_boring.rs"]
+#[cfg(feature = "openssl-tls")]
+#[path = "./server/tls_openssl.rs"]
 mod tls;
 
-#[cfg(not(any(feature = "rustls-tls", feature = "boring-tls")))]
+#[cfg(not(any(feature = "rustls-tls", feature = "openssl-tls")))]
 mod tls {
     use super::*;
 
     pub(super) struct TlsAcceptor;
 
     const PANIC_MESSAGE: &str = "using Kubert's `server` module requires one \
-        of the \"rustls-tls\" or \"boring-tls\" Cargo features to be enabled";
+        of the \"rustls-tls\" or \"openssl-tls\" Cargo features to be enabled";
 
     pub(super) async fn load_certs(
         pk: &TlsKeyPath,
@@ -51,6 +51,10 @@ mod tls {
         panic!("{PANIC_MESSAGE}")
     }
 }
+
+#[cfg(test)]
+mod tests;
+
 
 /// Command-line arguments used to configure a server
 #[derive(Clone, Debug)]
@@ -131,7 +135,7 @@ pub struct TlsCertPath(PathBuf);
 #[derive(Clone, Debug)]
 // TLS paths may not be used if TLS is not enabled.
 #[cfg_attr(
-    not(any(feature = "rustls-tls", feature = "boring-tls")),
+    not(any(feature = "rustls-tls", feature = "openssl-tls")),
     allow(dead_code)
 )]
 struct TlsPaths {
@@ -146,7 +150,7 @@ impl ServerArgs {
     ///
     /// # Panics
     ///
-    /// This method panics if neither of [the "rustls-tls" or "boring-tls" Cargo
+    /// This method panics if neither of [the "rustls-tls" or "openssl-tls" Cargo
     /// features][tls-features] are enabled. See [the module-level
     /// documentation][tls-doc] for details.
     ///

--- a/kubert/src/server/tests.rs
+++ b/kubert/src/server/tests.rs
@@ -34,7 +34,10 @@ fn gen_keys() -> (TempDir, TlsPaths) {
 
 #[tokio::test]
 // if no TLS features are enabled, this will panic.
-#[cfg_attr(not(any(feature = "rustls-tls", feature = "openssl-tls")), should_panic)]
+#[cfg_attr(
+    not(any(feature = "rustls-tls", feature = "openssl-tls")),
+    should_panic
+)]
 async fn load_tls() {
     let (_tempdir, TlsPaths { key, certs }) = gen_keys();
     match super::tls::load_tls(&key, &certs).await {

--- a/kubert/src/server/tests.rs
+++ b/kubert/src/server/tests.rs
@@ -1,0 +1,44 @@
+use super::*;
+use tempfile::TempDir;
+
+fn gen_keys() -> (TempDir, TlsPaths) {
+    use std::{fs::File, io::Write};
+
+    let dir = TempDir::with_prefix("kubert-test").expect("failed to create temporary directory");
+
+    let cert = rcgen::generate_simple_self_signed(vec!["kubert.test.example.com".to_string()])
+        .expect("failed to generate certs");
+
+    let certs = {
+        let path = dir.path().join("cert.pem");
+        let mut file = File::create(&path).expect("failed to create cert file");
+        let pem = cert
+            .serialize_pem()
+            .expect("failed to serializez certs PEM");
+        file.write_all(pem.as_bytes())
+            .expect("failed to write certs PEM to tempfile");
+        TlsCertPath(path)
+    };
+
+    let key = {
+        let path = dir.path().join("key.pem");
+        let mut file = File::create(&path).expect("failed to create private key file");
+        let pem = cert.serialize_private_key_pem();
+        file.write_all(pem.as_bytes())
+            .expect("failed to write private key PEM to tempfile");
+        TlsKeyPath(path)
+    };
+
+    (dir, TlsPaths { key, certs })
+}
+
+#[tokio::test]
+// if no TLS features are enabled, this will panic.
+#[cfg_attr(not(any(feature = "rustls-tls", feature = "openssl-tls")), should_panic)]
+async fn load_tls() {
+    let (_tempdir, TlsPaths { key, certs }) = gen_keys();
+    match super::tls::load_tls(&key, &certs).await {
+        Ok(_) => eprintln!("load_tls: success!"),
+        Err(error) => panic!("load_tls failed! {error}"),
+    }
+}

--- a/kubert/src/server/tls_openssl.rs
+++ b/kubert/src/server/tls_openssl.rs
@@ -12,10 +12,10 @@ use tokio_openssl::SslStream;
 pub(in crate::server) type TlsAcceptor = ssl::SslAcceptor;
 
 #[derive(Debug, thiserror::Error)]
-pub enum AcceptError {
-    #[error("failed to construct SSL from acceptor context: {0}")]
+pub(in crate::server) enum AcceptError {
+    #[error("failed to construct SSL session from acceptor context: {0}")]
     Ssl(#[source] ErrorStack),
-    #[error("failed to construct SslStream from SSL: {0}")]
+    #[error("failed to construct SslStream from SSL session: {0}")]
     Stream(#[source] ErrorStack),
     #[error("failed to accept TLS connection: {0}")]
     Accept(#[from] ssl::Error),

--- a/kubert/src/server/tls_openssl.rs
+++ b/kubert/src/server/tls_openssl.rs
@@ -116,7 +116,12 @@ impl TlsKeyPath {
         // Open keyfile.
         let pem = tokio::fs::read(&self.0).await?;
 
-        // Load and return a single private key.
+        // Load and return a single private key. The keyfile should be
+        // PEM-encoded.
+        // TODO(eliza): Potentially, we may want to support both PEM-encoded and
+        // DER-encoded keyfiles, and decide whether to use
+        // `PKey::private_key_from_pem` or `PKey::private_key_from_pkcs8` based
+        // on the filename extension.
         Ok(PKey::private_key_from_pem(&pem)?)
     }
 }

--- a/kubert/src/server/tls_openssl.rs
+++ b/kubert/src/server/tls_openssl.rs
@@ -117,6 +117,6 @@ impl TlsKeyPath {
         let pem = tokio::fs::read(&self.0).await?;
 
         // Load and return a single private key.
-        Ok(PKey::private_key_from_pkcs8(&pem)?)
+        Ok(PKey::private_key_from_pem(&pem)?)
     }
 }


### PR DESCRIPTION
Depends on #190 

Currently, Kubert has the option to use either Rustls or BoringSSL as the TLS implementation. However, the BoringSSL feature is incomplete, as it only configures Kubert's server to use BoringSSL, while the client will still use "whatever `kube-client` is configured to use". This means that you don't *really* get all-BoringSSL. Meanwhile, using BoringSSL on the client-side is quite fraught without upstream support in `kube-client`.

Therefore, this branch rips out the `boring-tls` feature and replaces it with an `openssl-tls` feature. Now, we can ensure that the client and server use the same TLS implementation, because `kube-client` already supports OpenSSL. In addition, I've added new tests for the TLS server, and changed the CI client tests to run with both TLS clients.

Closes #188 