### PR TITLE
admin: Replace 'metrics' with 'prometheus-client'

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -19,6 +19,16 @@ env:
   KUBERT_TEST_NS: kubert-test
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   local:
     strategy:
       matrix:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -17,6 +17,16 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   all-check:
     strategy:
       matrix:
@@ -40,7 +50,7 @@ jobs:
       matrix:
         feature:
           - admin
-          - admin,metrics
+          - admin,prometheus-client
           - client
           - "client rustls-tls"
           - "client openssl-tls"
@@ -50,7 +60,7 @@ jobs:
           - initialized
           - lease
           - log
-          - metrics
+          - prometheus-client
           - requeue
           - runtime
           - server

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,16 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   fmt:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/release-prometheus-process.yml
+++ b/.github/workflows/release-prometheus-process.yml
@@ -17,6 +17,16 @@ permissions:
   contents: read
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   meta:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/release-prometheus-process.yml
+++ b/.github/workflows/release-prometheus-process.yml
@@ -1,12 +1,12 @@
-name: Release
+name: Release kubernetes-prometheus-process
 
 on:
   pull_request:
     paths:
-      - .github/workflows/release.yml
+      - .github/workflows/release-prometheus-process.yml
   push:
     tags:
-      - 'release/*'
+      - 'kubert-prometheus-process/*'
 
 env:
   CARGO_INCREMENTAL: 0
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         run: |
           ref="${{ github.ref }}"
-          if [[ "$ref" == refs/tags/release/* ]]; then
-            version="${ref##refs/tags/release/}"
-            crate=$(just-cargo crate-version kubert)
+          if [[ "$ref" == refs/tags/kubert-prometheus-process/* ]]; then
+            version="${ref##refs/tags/kubert-prometheus-process/}"
+            crate=$(just-cargo crate-version kubert-prometheus-process)
             if [[ "$crate" != "$version" ]]; then
               echo "::error ::Crate version $crate does not match tag $version" >&2
               exit 1
@@ -39,7 +39,7 @@ jobs:
             ) >> "$GITHUB_OUTPUT"
           else
             sha="${{ github.sha }}"
-            ( echo version="$(just-cargo crate-version kubert)-git-${sha:0:7}"
+            ( echo version="$(just-cargo crate-version kubert-prometheus-process)-git-${sha:0:7}"
               echo mode=test
             ) >> "$GITHUB_OUTPUT"
           fi
@@ -68,6 +68,6 @@ jobs:
     container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - run: cargo publish --package=kubert --dry-run
+      - run: cargo publish --package=kubert-prometheus-process --dry-run
       - if: needs.meta.outputs.mode == 'release'
-        run: cargo publish --package=kubert --token=${{ secrets.CRATESIO_TOKEN }}
+        run: cargo publish --package=kubert-prometheus-process --token=${{ secrets.CRATESIO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release kubert
 
 on:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,16 @@ permissions:
   contents: read
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   meta:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,16 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "2"
-default-members = ["kubert"]
+default-members = ["kubert", "kubert-prometheus-process"]
 members = [
     "kubert",
+    "kubert-prometheus-process",
     "examples",
 ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Rust Kubernetes runtime helpers. Based on [`kube-rs`][krs].
 
 * [`clap`](https://docs.rs/clap) command-line interface support;
 * A basic admin server with `/ready` and `/live` probe endpoints;
-* Optional Prometheus [`metrics`][mt] integration;
+* Optional [`prometheus-client`][pc] integration;
 * A default Kubernetes client;
 * Graceful shutdown on `SIGTERM` or `SIGINT` signals;
 * An HTTPS server (for admission controllers and API extensions) with
@@ -46,11 +46,17 @@ Other examples include:
 
 * [Linkerd2 policy controller](https://github.com/linkerd/linkerd2/blob/d4543cd86e427b241ce961b50dd83b1738c0b069/policy-controller/src/main.rs)
 
+## kubert-prometheus-process
+
+The `kubert-prometheus-process` crate provides a process metrics collector
+prometheus-client. It has no dependencies on kubert, and can be used
+independently.
+
 ## Status
 
 This crate is still fairly experimental, though it's based on production code
 from Linkerd; and we plan to use it in Linkerd moving forward.
 
 [krs]: https://docs.rs/kube
-[mt]: https://docs.rs/metrics
+[pc]: https://docs.rs/prometheus-client
 [rt]: https://docs.rs/kubert/latest/kubert/runtime/struct.Runtime.html

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other examples include:
 
 ## kubert-prometheus-process
 
-The `kubert-prometheus-process` crate provides a process metrics collector
+The `kubert-prometheus-process` crate provides [process metrics][pm] for
 prometheus-client. It has no dependencies on kubert, and can be used
 independently.
 
@@ -59,4 +59,5 @@ from Linkerd; and we plan to use it in Linkerd moving forward.
 
 [krs]: https://docs.rs/kube
 [pc]: https://docs.rs/prometheus-client
+[pm]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
 [rt]: https://docs.rs/kubert/latest/kubert/runtime/struct.Runtime.html

--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,9 @@ exceptions = [
         "Apache-2.0",
         "Unicode-DFS-2016",
     ], name = "unicode-ident" },
-    { allow = ["Zlib"], name = "adler32" },
+    { allow = [
+        "Zlib",
+    ], name = "adler32" },
 ]
 
 [[licenses.clarify]]
@@ -52,7 +54,7 @@ skip = [
     { name = "base64" },
     # the current versions of `hyper` and `tokio` depend on semver-incompatible
     # versions of `socket2` (0.4 and 0.5, respectively).
-    { name = "socket2" }
+    { name = "socket2" },
 ]
 skip-tree = [
     { name = "windows-sys" },
@@ -61,15 +63,8 @@ skip-tree = [
     { name = "windows_i686_msvc" },
     { name = "windows_x86_64_gnu" },
     { name = "windows_x86_64_msvc" },
-    # `metrics` and `kube-runtime` have conflicting versions of `ahash` and
-    # `wasi`.
-    # TODO(eliza): remove this skip when the conflicts are resolved.
-    { name = "metrics" },
-    # `metrics-process` has transitive deps on `hermit-abi` and `bitflags` that
-    # are incompatible with the transitive deps other crates have on those
-    # libraries.
-    # TODO(eliza): remove this skip when the conflicts are resolved.
-    { name = "metrics-process" },
+    # tracing-subscriber needs an older regex-automata.
+    { name = "regex-automata" },
     # `serde_json` and `serde_yaml` depend on incompatible versions of indexmap
     { name = "indexmap" },
     # the proc-macro ecosystem is still in the process of migrating from `syn`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ openssl-tls = ["kubert/openssl-tls", "openssl"]
 [dependencies.kubert]
 path = "../kubert"
 default-features = false
-features = ["clap", "lease", "runtime"]
+features = ["clap", "lease", "prometheus-client", "runtime"]
 
 [dependencies.openssl]
 version = "0.10.57"
@@ -29,6 +29,7 @@ anyhow = "1"
 chrono = { version = "0.4", default-features = false }
 futures = { version = "0.3", default-features = false }
 maplit = "1"
+prometheus-client = "0.22"
 rand = "0.8"
 regex = "1"
 thiserror = "1"

--- a/kubert-prometheus-process/Cargo.toml
+++ b/kubert-prometheus-process/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kubert-prometheus-process"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "A prometheus-client process metrics collector"
+readme = "../README.md"
+repository = "https://github.com/olix0r/kubert"
+rust-version = "1.65"
+keywords = ["prometheus-client", "process", "metrics", "monitoring"]
+
+[dependencies]
+prometheus-client = "0.22.0"
+tracing = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+procfs = { version = "0.16", default-features = false }

--- a/kubert-prometheus-process/src/lib.rs
+++ b/kubert-prometheus-process/src/lib.rs
@@ -1,0 +1,254 @@
+//! Unsafe code for accessing system-level counters for memory & CPU usage.
+//!
+//! Based on linkerd2-proxy.
+//!
+//
+// Copyright The Linkerd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![deny(rust_2018_idioms, clippy::disallowed_methods, unsafe_code)]
+
+use prometheus_client::{
+    collector::Collector,
+    encoding::{DescriptorEncoder, EncodeMetric},
+    metrics::{counter::ConstCounter, gauge::ConstGauge, MetricType},
+    registry::{Registry, Unit},
+};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+pub fn register(reg: &mut Registry) -> std::io::Result<()> {
+    let start_time = Instant::now();
+    let start_time_from_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("process start time");
+
+    #[cfg(target_os = "linux")]
+    let system = linux::System::load()?;
+
+    reg.register_with_unit(
+        "start_time",
+        "Time that the process started (in seconds since the UNIX epoch)",
+        Unit::Seconds,
+        ConstGauge::new(start_time_from_epoch.as_secs_f64()),
+    );
+
+    reg.register_collector(Box::new(ProcessCollector {
+        start_time,
+        #[cfg(target_os = "linux")]
+        system,
+    }));
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ProcessCollector {
+    start_time: Instant,
+    #[cfg(target_os = "linux")]
+    system: linux::System,
+}
+
+impl Collector for ProcessCollector {
+    fn encode(&self, mut encoder: DescriptorEncoder<'_>) -> std::fmt::Result {
+        let uptime = ConstCounter::new(
+            Instant::now()
+                .saturating_duration_since(self.start_time)
+                .as_secs_f64(),
+        );
+        let ue = encoder.encode_descriptor(
+            "uptime",
+            "Total time since the process started (in seconds)",
+            Some(&Unit::Seconds),
+            MetricType::Counter,
+        )?;
+        uptime.encode(ue)?;
+
+        #[cfg(target_os = "linux")]
+        self.system.encode(encoder)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+    use libc::{self, pid_t};
+    use process::Stat;
+    use procfs::{
+        process::{self, LimitValue, Process},
+        ProcResult,
+    };
+    use std::time::Duration;
+    use std::{fs, io};
+    use tracing::{error, warn};
+
+    #[derive(Clone, Debug)]
+    pub(super) struct System {
+        page_size: u64,
+        ms_per_tick: u64,
+    }
+
+    impl System {
+        pub fn load() -> std::io::Result<Self> {
+            let page_size = page_size()?;
+            let ms_per_tick = ms_per_tick()?;
+            Ok(Self {
+                page_size,
+                ms_per_tick,
+            })
+        }
+    }
+
+    impl Collector for System {
+        fn encode(&self, mut encoder: DescriptorEncoder<'_>) -> std::fmt::Result {
+            let stat = match blocking_stat() {
+                Ok(stat) => stat,
+                Err(error) => {
+                    tracing::warn!(%error, "Failed to read process stats");
+                    return Ok(());
+                }
+            };
+
+            let clock_ticks = stat.utime + stat.stime;
+            let cpu = ConstCounter::new(
+                Duration::from_millis(clock_ticks * self.ms_per_tick).as_secs_f64(),
+            );
+            let cpue = encoder.encode_descriptor(
+                "cpu",
+                "Total user and system CPU time spent in seconds",
+                Some(&Unit::Seconds),
+                MetricType::Counter,
+            )?;
+            cpu.encode(cpue)?;
+
+            let vm_bytes = ConstGauge::new(stat.vsize as i64);
+            let vme = encoder.encode_descriptor(
+                "virtual_memory",
+                "Virtual memory size in bytes",
+                Some(&Unit::Bytes),
+                MetricType::Gauge,
+            )?;
+            vm_bytes.encode(vme)?;
+
+            let rss_bytes = ConstGauge::new((stat.rss * self.page_size) as i64);
+            let rsse = encoder.encode_descriptor(
+                "resident_memory",
+                "Resident memory size in bytes",
+                Some(&Unit::Bytes),
+                MetricType::Gauge,
+            )?;
+            rss_bytes.encode(rsse)?;
+
+            match open_fds(stat.pid) {
+                Ok(open_fds) => {
+                    let fds = ConstGauge::new(open_fds as i64);
+                    let fdse = encoder.encode_descriptor(
+                        "open_fds",
+                        "Number of open file descriptors",
+                        None,
+                        MetricType::Gauge,
+                    )?;
+                    fds.encode(fdse)?;
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Could not determine open fds");
+                }
+            }
+
+            match max_fds() {
+                Ok(max_fds) => {
+                    let fds = ConstGauge::new(max_fds as i64);
+                    let fdse = encoder.encode_descriptor(
+                        "max_fds",
+                        "Maximum number of open file descriptors",
+                        None,
+                        MetricType::Gauge,
+                    )?;
+                    fds.encode(fdse)?;
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Could not determine max fds");
+                }
+            }
+
+            let threads = ConstGauge::new(stat.num_threads);
+            let te = encoder.encode_descriptor(
+                "threads",
+                "Number of OS threads in the process.",
+                None,
+                MetricType::Gauge,
+            )?;
+            threads.encode(te)?;
+
+            Ok(())
+        }
+    }
+
+    fn page_size() -> io::Result<u64> {
+        sysconf(libc::_SC_PAGESIZE, "page size")
+    }
+
+    fn ms_per_tick() -> io::Result<u64> {
+        // On Linux, CLK_TCK is ~always `100`, so pure integer division
+        // works. This is probably not suitable if we encounter other
+        // values.
+        let clock_ticks_per_sec = sysconf(libc::_SC_CLK_TCK, "clock ticks per second")?;
+        let ms_per_tick = 1_000 / clock_ticks_per_sec;
+        if clock_ticks_per_sec != 100 {
+            warn!(
+                clock_ticks_per_sec,
+                ms_per_tick, "Unexpected value; process_cpu_seconds_total may be inaccurate."
+            );
+        }
+        Ok(ms_per_tick)
+    }
+
+    fn blocking_stat() -> ProcResult<Stat> {
+        Process::myself()?.stat()
+    }
+
+    fn open_fds(pid: pid_t) -> io::Result<u64> {
+        let mut open = 0;
+        for f in fs::read_dir(format!("/proc/{}/fd", pid))? {
+            if !f?.file_type()?.is_dir() {
+                open += 1;
+            }
+        }
+        Ok(open)
+    }
+
+    fn max_fds() -> ProcResult<u64> {
+        let limits = Process::myself()?.limits()?.max_open_files;
+        match limits.soft_limit {
+            LimitValue::Unlimited => match limits.hard_limit {
+                LimitValue::Unlimited => Ok(0),
+                LimitValue::Value(hard) => Ok(hard),
+            },
+            LimitValue::Value(soft) => Ok(soft),
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn sysconf(num: libc::c_int, name: &'static str) -> Result<u64, io::Error> {
+        match unsafe { libc::sysconf(num) } {
+            e if e <= 0 => {
+                let error = io::Error::last_os_error();
+                error!("error getting {}: {:?}", name, error);
+                Err(error)
+            }
+            val => Ok(val as u64),
+        }
+    }
+}

--- a/kubert-prometheus-process/src/lib.rs
+++ b/kubert-prometheus-process/src/lib.rs
@@ -1,7 +1,20 @@
-//! Unsafe code for accessing system-level counters for memory & CPU usage.
+//! Process metrics for Prometheus.
 //!
-//! Based on linkerd2-proxy.
+//! This crate registers a collector that provides the standard set of [Process
+//! metrics][pm].
 //!
+//! ```
+//! let mut prom = prometheus_client::registry::Registry::default();
+//! if let Err(error) =
+//!     kubert_prometheus_process::register(prom.sub_registry_with_prefix("process"))
+//! {
+//!     tracing::warn!(%error, "Failed to register process metrics");
+//! }
+//! ```
+//!
+//! [pm]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
+//
+// Based on linkerd2-proxy.
 //
 // Copyright The Linkerd Authors
 //
@@ -17,7 +30,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(rust_2018_idioms, clippy::disallowed_methods, unsafe_code)]
+#![deny(
+    rust_2018_idioms,
+    clippy::disallowed_methods,
+    unsafe_code,
+    missing_docs
+)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use prometheus_client::{
     collector::Collector,
@@ -27,6 +46,8 @@ use prometheus_client::{
 };
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+/// Registers process metrics with the given registry. Note that the 'process_'
+/// prefix is NOT added and should be specified by the caller if desired.
 pub fn register(reg: &mut Registry) -> std::io::Result<()> {
     let start_time = Instant::now();
     let start_time_from_epoch = SystemTime::now()

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -73,7 +73,11 @@ lease = [
     "tracing",
 ]
 log = ["thiserror", "tracing", "tracing-subscriber"]
-metrics = ["deflate", "metrics-exporter-prometheus", "metrics-process"]
+prometheus-client = [
+    "dep:deflate",
+    "dep:prometheus-client",
+    "dep:kubert-prometheus-process",
+]
 requeue = [
     "futures-core",
     "tokio/macros",
@@ -130,7 +134,7 @@ features = [
     "initialized",
     "lease",
     "log",
-    "metrics",
+    "prometheus-client",
     "requeue",
     "runtime",
     "server",
@@ -152,12 +156,12 @@ futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
 hyper = { version = "0.14.17", optional = true, default-features = false }
 hyper-openssl = { version = "0.9.2", optional = true }
-metrics-exporter-prometheus = { version = "0.12.0", optional = true, default-features = false }
-metrics-process = { version = "1.0.11", optional = true }
+kubert-prometheus-process = { version = "0.1.0", path = "../kubert-prometheus-process", optional = true }
 once_cell = { version = "1", optional = true }
 openssl = { version = "0.10.57", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
+prometheus-client = { version = "0.22.0", optional = true, default-features = false }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,65 +1,69 @@
 use super::*;
 
 use hyper::header;
-pub(super) use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
-use std::fmt;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) struct Prometheus {
-    metrics: PrometheusHandle,
-    collect: Arc<dyn Fn() + Send + Sync + 'static>,
+    registry: Arc<prometheus_client::registry::Registry>,
 }
 
 impl Prometheus {
-    pub(super) fn new(
-        metrics: PrometheusHandle,
-        collect: impl Fn() + Send + Sync + 'static,
-    ) -> Self {
+    pub(super) fn new(reg: prometheus_client::registry::Registry) -> Self {
         Self {
-            metrics,
-            collect: Arc::new(collect),
+            registry: reg.into(),
         }
     }
 
     pub(super) fn handle_metrics(&self, req: Request<Body>) -> Response<Body> {
-        match *req.method() {
-            hyper::Method::GET | hyper::Method::HEAD => {
-                let mut rsp = Response::builder()
-                    .status(hyper::StatusCode::OK)
-                    .header(header::CONTENT_TYPE, "text/plain");
-
-                // TODO(ver) Limit collection frequency.
-                (*self.collect)();
-
-                let metrics = self.metrics.render();
-                // if the requestor accepts gzip compression, compress the metrics.
-                let body = if accepts_gzip(req.headers()) {
-                    // XXX(eliza): it's a shame we can't have the `PrometheusHandle`
-                    // format the metrics into a writer, rather than into a
-                    // string...if we could, we could write directly to the gzip
-                    // writer and not have to double-allocate in that case.
-                    rsp = rsp.header(header::CONTENT_ENCODING, "gzip");
-                    deflate::deflate_bytes_gzip(metrics.as_bytes()).into()
-                } else {
-                    metrics.into()
-                };
-
-                rsp.body(body).unwrap()
-            }
-            _ => Response::builder()
+        if !matches!(*req.method(), hyper::Method::GET | hyper::Method::HEAD) {
+            return Response::builder()
                 .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
                 .header(header::ALLOW, "GET, HEAD")
                 .body(Body::default())
-                .unwrap(),
+                .unwrap();
         }
-    }
-}
 
-impl fmt::Debug for Prometheus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Prometheus")
-            .field("metrics", &format_args!("PrometheusHandle {{ ... }}"))
-            .finish()
+        let gzip = accepts_gzip(req.headers());
+        let body = match self.encode_body(gzip) {
+            Ok(body) => body,
+            Err(error) => {
+                tracing::error!(%error, "Failed to encode metrics");
+                return Response::builder()
+                    .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::default())
+                    .unwrap();
+            }
+        };
+
+        let mut rsp = Response::builder().status(hyper::StatusCode::OK).header(
+            header::CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        );
+        if gzip {
+            rsp = rsp.header(header::CONTENT_ENCODING, "gzip");
+        }
+        rsp.body(body).expect("response must be valid")
+    }
+
+    fn encode_body(&self, gzip: bool) -> std::result::Result<hyper::Body, std::fmt::Error> {
+        if gzip {
+            struct GzFmt<'a>(&'a mut deflate::write::GzEncoder<Vec<u8>>);
+            impl<'a> std::fmt::Write for GzFmt<'a> {
+                fn write_str(&mut self, s: &str) -> std::fmt::Result {
+                    use std::io::Write as _;
+                    self.0.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)
+                }
+            }
+
+            let mut gz = deflate::write::GzEncoder::new(vec![], deflate::Compression::Fast);
+            prometheus_client::encoding::text::encode(&mut GzFmt(&mut gz), &self.registry)?;
+            let buf = gz.finish().map_err(|_| std::fmt::Error)?;
+            return Ok(hyper::Body::from(buf));
+        }
+
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &self.registry)?;
+        Ok(hyper::Body::from(buf))
     }
 }
 


### PR DESCRIPTION
This change replaces the `metrics` feature with a `prometheus-client` feature. prometheus-client is the official Prometheus-org OpenMetrics implementation.

The watch-pods example has been updated to export prometheus metrics:

    :; curl localhost:8080/metrics
    # HELP watch_pods_events Number of events observed.
    # TYPE watch_pods_events counter
    watch_pods_events_total{op="apply"} 0
    watch_pods_events_total{op="delete"} 0
    watch_pods_events_total{op="restart"} 1
    # HELP watch_pods_current_pods Number of Pods being observed.
    # TYPE watch_pods_current_pods gauge
    watch_pods_current_pods 10
    # HELP watch_pods_pods Total number of unique pods observed.
    # TYPE watch_pods_pods counter
    watch_pods_pods_total 10
    # HELP process_start_time_seconds Time that the process started (in seconds since the UNIX epoch).                                                                                                    
    # TYPE process_start_time_seconds gauge
    # UNIT process_start_time_seconds seconds
    process_start_time_seconds 1702159727.213669
    # HELP process_uptime_seconds Total time since the process started (in seconds)
    # TYPE process_uptime_seconds counter
    # UNIT process_uptime_seconds seconds
    process_uptime_seconds_total 2.712104395
    # HELP process_cpu_seconds Total user and system CPU time spent in seconds
    # TYPE process_cpu_seconds counter
    # UNIT process_cpu_seconds seconds
    process_cpu_seconds_total 0.73
    # HELP process_virtual_memory_bytes Virtual memory size in bytes
    # TYPE process_virtual_memory_bytes gauge
    # UNIT process_virtual_memory_bytes bytes
    process_virtual_memory_bytes 1208897536
    # HELP process_resident_memory_bytes Resident memory size in bytes
    # TYPE process_resident_memory_bytes gauge
    # UNIT process_resident_memory_bytes bytes
    process_resident_memory_bytes 21114880
    # HELP process_open_fds Number of open file descriptors
    # TYPE process_open_fds gauge
    process_open_fds 16
    # HELP process_max_fds Maximum number of open file descriptors
    # TYPE process_max_fds gauge
    process_max_fds 1048576
    # HELP process_threads Number of OS threads in the process.
    # TYPE process_threads gauge
    process_threads 18
    # EOF

Furthermore, `admin::Builder` APIs are updated to consume the builder and return it by-value (instead of handling references, which does not work well when chaining configuration). This is based on the experience of integrating prometheus into the example.

Additionally, the admin server has been updated to use spawn_blocking for non-probe handlers.

To support this, a new kubert-prometheus-process crate has been added, including only the procfs bindings needed to support the process metrics. This crate is completely decoupled from kubert. It is based on the process metrics implementation in the linkerd2-proxy repo.