### PR TITLE
examples: Update lease to export metrics

### DIFF
--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     let mut prom = prometheus_client::registry::Registry::default();
 
     // Register application metrics before configuring the admin server.
-    let metrics = Metrics::register(prom.sub_registry_with_prefix("watch_pods"));
+    let metrics = Metrics::register(prom.sub_registry_with_prefix("kubert_watch_pods"));
 
     // Configure a runtime with:
     // - a Kubernetes client


### PR DESCRIPTION
The lease example now exports the lease state as a metric:

    # HELP kubert_lease_claimed Indicates whether this instance is owns the lease.
    # TYPE kubert_lease_claimed gauge
    kubert_lease_claimed 1
    # HELP kubert_lease_claim_changes Counts changes of this process's claim of the lease.
    # TYPE kubert_lease_claim_changes counter
    kubert_lease_claim_changes_total 1

    # HELP kubert_lease_claimed Indicates whether this instance is owns the lease.
    # TYPE kubert_lease_claimed gauge
    kubert_lease_claimed 0
    # HELP kubert_lease_claim_changes Counts changes of this process's claim of the lease.
    # TYPE kubert_lease_claim_changes counter
    kubert_lease_claim_changes_total 2