### PR TITLE
Add prometheus metrics for resource watch events

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -64,6 +64,7 @@ jobs:
           - prometheus-client
           - requeue
           - runtime
+          - runtime,prometheus-client
           - server
           - "server rustls-tls"
           - "server openssl-tls"

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -72,9 +72,8 @@ async fn main() -> Result<()> {
     let mut prom = prometheus_client::registry::Registry::default();
 
     // Register application metrics before configuring the admin server.
-    let metrics = Metrics::register(prom.sub_registry_with_prefix("pods"));
-    let runtime_metrics =
-        RuntimeMetrics::new(prom.sub_registry_with_prefix("kubert_resource_watch"));
+    let metrics = Metrics::register(prom.sub_registry_with_prefix("example_watch_pods"));
+    let runtime_metrics = RuntimeMetrics::register(prom.sub_registry_with_prefix("kubert"));
 
     // Configure a runtime with:
     // - a Kubernetes client

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -9,7 +9,6 @@ use kube::{
     runtime::watcher::{self, Event},
     ResourceExt,
 };
-use kubert::runtime::RuntimeMetrics;
 use prometheus_client::metrics::{counter::Counter, family::Family, gauge::Gauge};
 use tokio::time;
 use tracing::Instrument;
@@ -73,7 +72,7 @@ async fn main() -> Result<()> {
 
     // Register application metrics before configuring the admin server.
     let metrics = Metrics::register(prom.sub_registry_with_prefix("example_watch_pods"));
-    let runtime_metrics = RuntimeMetrics::register(prom.sub_registry_with_prefix("kubert"));
+    let runtime_metrics = kubert::RuntimeMetrics::register(prom.sub_registry_with_prefix("kubert"));
 
     // Configure a runtime with:
     // - a Kubernetes client

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -9,7 +9,7 @@ use kube::{
     runtime::watcher::{self, Event},
     ResourceExt,
 };
-use kubert::runtime::ResourceWatchMetrics;
+use kubert::runtime::RuntimeMetrics;
 use prometheus_client::metrics::{counter::Counter, family::Family, gauge::Gauge};
 use tokio::time;
 use tracing::Instrument;
@@ -73,8 +73,8 @@ async fn main() -> Result<()> {
 
     // Register application metrics before configuring the admin server.
     let metrics = Metrics::register(prom.sub_registry_with_prefix("pods"));
-    let watch_metrics =
-        ResourceWatchMetrics::new(prom.sub_registry_with_prefix("kubert_resource_watch"));
+    let runtime_metrics =
+        RuntimeMetrics::new(prom.sub_registry_with_prefix("kubert_resource_watch"));
 
     // Configure a runtime with:
     // - a Kubernetes client
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
     let rt = kubert::Runtime::builder()
         .with_log(log_level, log_format)
         .with_admin(admin.into_builder().with_prometheus(prom))
-        .with_metrics(watch_metrics)
+        .with_metrics(runtime_metrics)
         .with_client(client);
 
     let deadline = time::Instant::now() + timeout;

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -130,5 +130,8 @@ pub use self::log::{LogFilter, LogFormat, LogInitError};
 #[cfg(feature = "runtime")]
 pub use self::runtime::Runtime;
 
+#[cfg(all(feature = "runtime", feature = "prometheus-client"))]
+pub use self::runtime::RuntimeMetrics;
+
 #[cfg(feature = "server")]
 pub use self::server::ServerArgs;

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -12,11 +12,6 @@ use crate::{
 use futures_core::Stream;
 use kube_core::{NamespaceResourceScope, Resource};
 use kube_runtime::{reflector, watcher};
-#[cfg(feature = "prometheus-client")]
-use metrics::ResourceWatchMetrics;
-#[cfg(feature = "prometheus-client")]
-use prometheus_client::registry::Registry;
-#[cfg(feature = "prometheus-client")]
 use serde::de::DeserializeOwned;
 use std::{fmt::Debug, future::Future, hash::Hash, time::Duration};
 #[cfg(feature = "server")]
@@ -84,7 +79,7 @@ pub struct NoServer(());
 #[must_use = "RuntimeMetrics must be passed to `Builder::with_metrics`"]
 #[derive(Debug)]
 pub struct RuntimeMetrics {
-    watch: ResourceWatchMetrics,
+    watch: metrics::ResourceWatchMetrics,
 }
 
 /// Indicates that the [`Builder`] could not configure a [`Runtime`]
@@ -596,11 +591,11 @@ impl LogSettings {
 
 // === impl RuntimeMetrics ===
 
+#[cfg(feature = "prometheus-client")]
 impl RuntimeMetrics {
     /// Creates a new set of metrics and registers them.
-    #[cfg(feature = "prometheus-client")]
-    pub fn register(registry: &mut Registry) -> Self {
-        let watch = ResourceWatchMetrics::register(registry);
+    pub fn register(registry: &mut prometheus_client::registry::Registry) -> Self {
+        let watch = metrics::ResourceWatchMetrics::register(registry);
         Self { watch }
     }
 }

--- a/kubert/src/runtime.rs
+++ b/kubert/src/runtime.rs
@@ -595,7 +595,8 @@ impl LogSettings {
 impl RuntimeMetrics {
     /// Creates a new set of metrics and registers them.
     pub fn register(registry: &mut prometheus_client::registry::Registry) -> Self {
-        let watch = metrics::ResourceWatchMetrics::register(registry);
+        let watch =
+            metrics::ResourceWatchMetrics::register(registry.sub_registry_with_prefix("watch"));
         Self { watch }
     }
 }

--- a/kubert/src/runtime/metrics.rs
+++ b/kubert/src/runtime/metrics.rs
@@ -3,7 +3,7 @@ use futures_util::StreamExt;
 use kube_core::Resource;
 use kube_runtime::watcher;
 use prometheus_client::{
-    encoding::EncodeLabelSet,
+    encoding::{EncodeLabelSet, EncodeLabelValue},
     metrics::{counter::Counter, family::Family},
     registry::Registry,
 };
@@ -12,49 +12,41 @@ use std::fmt::Debug;
 /// Metrics for tracking resource watch events.
 #[derive(Clone, Debug)]
 pub(super) struct ResourceWatchMetrics {
-    watch_applies: Family<ResourceWatchLabels, Counter>,
-    watch_restarts: Family<ResourceWatchLabels, Counter>,
-    watch_deletes: Family<ResourceWatchLabels, Counter>,
-    watch_errors: Family<ResourceWatchErrorLabels, Counter>,
+    watch_events: Family<EventLabels, Counter>,
+    watch_errors: Family<ErrorLabels, Counter>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-struct ResourceWatchLabels {
+struct EventLabels {
+    op: EventOp,
     kind: String,
     group: String,
     version: String,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-struct ResourceWatchErrorLabels {
+struct ErrorLabels {
     kind: String,
     group: String,
     version: String,
     error: &'static str,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+enum EventOp {
+    Apply,
+    Restart,
+    Delete,
+}
+
 impl ResourceWatchMetrics {
     /// Creates a new set of metrics and registers them.
     pub(super) fn register(registry: &mut Registry) -> Self {
-        let watch_applies = Family::default();
+        let watch_events = Family::default();
         registry.register(
-            "applies",
+            "events",
             "Count of apply events for a resource watch",
-            watch_applies.clone(),
-        );
-
-        let watch_restarts = Family::default();
-        registry.register(
-            "restarts",
-            "Count of restart events for a resource watch",
-            watch_restarts.clone(),
-        );
-
-        let watch_deletes = Family::default();
-        registry.register(
-            "deletes",
-            "Count of delete events for a resource watch",
-            watch_deletes.clone(),
+            watch_events.clone(),
         );
 
         let watch_errors = Family::default();
@@ -65,9 +57,7 @@ impl ResourceWatchMetrics {
         );
 
         Self {
-            watch_applies,
-            watch_restarts,
-            watch_deletes,
+            watch_events,
             watch_errors,
         }
     }
@@ -86,40 +76,52 @@ impl ResourceWatchMetrics {
         let kind = T::kind(&dt).into_owned();
         let group = T::group(&dt).into_owned();
         let version = T::version(&dt).into_owned();
-        let labels = ResourceWatchLabels {
+        let apply_labels = EventLabels {
             kind,
             group,
             version,
+            op: EventOp::Apply,
+        };
+        let restart_labels = EventLabels {
+            op: EventOp::Restart,
+            ..apply_labels.clone()
+        };
+        let delete_labels = EventLabels {
+            op: EventOp::Delete,
+            ..apply_labels.clone()
+        };
+        let error_labels = ErrorLabels {
+            kind: apply_labels.kind.clone(),
+            group: apply_labels.group.clone(),
+            version: apply_labels.version.clone(),
+            error: "", // replaced later
         };
 
         watch.map(move |event| {
             if let Some(metrics) = &metrics {
                 match event {
-                    Ok(watcher::Event::Applied(_)) => {
-                        metrics.watch_applies.get_or_create(&labels).inc();
-                    }
                     Ok(watcher::Event::Restarted(_)) => {
-                        metrics.watch_restarts.get_or_create(&labels).inc();
+                        metrics.watch_events.get_or_create(&restart_labels).inc();
+                    }
+                    Ok(watcher::Event::Applied(_)) => {
+                        metrics.watch_events.get_or_create(&apply_labels).inc();
                     }
                     Ok(watcher::Event::Deleted(_)) => {
-                        metrics.watch_deletes.get_or_create(&labels).inc();
+                        metrics.watch_events.get_or_create(&delete_labels).inc();
                     }
                     Err(ref e) => {
-                        let error = match e {
-                            watcher::Error::InitialListFailed(_) => "InitialListFailed",
-                            watcher::Error::WatchStartFailed(_) => "WatchStartFailed",
-                            watcher::Error::WatchError(_) => "WatchError",
-                            watcher::Error::WatchFailed(_) => "WatchFailed",
-                            watcher::Error::NoResourceVersion => "NoResourceVersion",
-                            watcher::Error::TooManyObjects => "TooManyObjects",
+                        let labels = ErrorLabels {
+                            error: match e {
+                                watcher::Error::InitialListFailed(_) => "InitialListFailed",
+                                watcher::Error::WatchStartFailed(_) => "WatchStartFailed",
+                                watcher::Error::WatchError(_) => "WatchError",
+                                watcher::Error::WatchFailed(_) => "WatchFailed",
+                                watcher::Error::NoResourceVersion => "NoResourceVersion",
+                                watcher::Error::TooManyObjects => "TooManyObjects",
+                            },
+                            ..error_labels.clone()
                         };
-                        let error_labels = ResourceWatchErrorLabels {
-                            kind: labels.kind.clone(),
-                            group: labels.group.clone(),
-                            version: labels.version.clone(),
-                            error,
-                        };
-                        metrics.watch_errors.get_or_create(&error_labels).inc();
+                        metrics.watch_errors.get_or_create(&labels).inc();
                     }
                 };
             }

--- a/kubert/src/runtime/metrics.rs
+++ b/kubert/src/runtime/metrics.rs
@@ -1,0 +1,132 @@
+use std::borrow::Cow;
+
+use futures_core::Stream;
+use futures_util::StreamExt;
+use kube_core::Resource;
+use kube_runtime::watcher;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{counter::Counter, family::Family},
+    registry::Registry,
+};
+use serde::de::DeserializeOwned;
+use std::fmt::Debug;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct ResourceWatchLabels {
+    kind: Cow<'static, str>,
+    group: Cow<'static, str>,
+    version: Cow<'static, str>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct ResourceWatchErrorLabels {
+    kind: Cow<'static, str>,
+    group: Cow<'static, str>,
+    version: Cow<'static, str>,
+    error: Cow<'static, str>,
+}
+
+/// Metrics for tracking resource watch events.
+#[cfg(feature = "prometheus-client")]
+#[derive(Clone, Debug)]
+pub(super) struct ResourceWatchMetrics {
+    watch_applies: Family<ResourceWatchLabels, Counter>,
+    watch_restarts: Family<ResourceWatchLabels, Counter>,
+    watch_deletes: Family<ResourceWatchLabels, Counter>,
+    watch_errors: Family<ResourceWatchErrorLabels, Counter>,
+}
+
+#[cfg(feature = "prometheus-client")]
+impl ResourceWatchMetrics {
+    /// Creates a new set of metrics and registers them.
+    pub(super) fn new(registry: &mut Registry) -> Self {
+        let watch_applies = Family::default();
+        registry.register(
+            "applies",
+            "Count of apply events for a resource watch",
+            watch_applies.clone(),
+        );
+
+        let watch_restarts = Family::default();
+        registry.register(
+            "restarts",
+            "Count of restart events for a resource watch",
+            watch_restarts.clone(),
+        );
+
+        let watch_deletes = Family::default();
+        registry.register(
+            "deletes",
+            "Count of delete events for a resource watch",
+            watch_deletes.clone(),
+        );
+
+        let watch_errors = Family::default();
+        registry.register(
+            "errors",
+            "Count of errors for a resource watch",
+            watch_errors.clone(),
+        );
+
+        Self {
+            watch_applies,
+            watch_restarts,
+            watch_deletes,
+            watch_errors,
+        }
+    }
+}
+
+impl ResourceWatchMetrics {
+    pub(crate) fn instrument_watch<T, S: Stream<Item = watcher::Result<watcher::Event<T>>> + Send>(
+        metrics: Option<Self>,
+        watch: S,
+    ) -> impl Stream<Item = watcher::Result<watcher::Event<T>>> + Send
+    where
+        T: Resource<DynamicType = ()> + DeserializeOwned + Clone + Debug + Send + 'static,
+    {
+        let kind = T::kind(&());
+        let group = T::group(&());
+        let version = T::version(&());
+        let labels = ResourceWatchLabels {
+            kind,
+            group,
+            version,
+        };
+
+        watch.map(move |event| {
+            if let Some(metrics) = &metrics {
+                match event {
+                    Ok(watcher::Event::Applied(_)) => {
+                        metrics.watch_applies.get_or_create(&labels).inc();
+                    }
+                    Ok(watcher::Event::Restarted(_)) => {
+                        metrics.watch_restarts.get_or_create(&labels).inc();
+                    }
+                    Ok(watcher::Event::Deleted(_)) => {
+                        metrics.watch_deletes.get_or_create(&labels).inc();
+                    }
+                    Err(ref e) => {
+                        let error = match e {
+                            watcher::Error::InitialListFailed(_) => "InitialListFailed",
+                            watcher::Error::WatchStartFailed(_) => "WatchStartFailed",
+                            watcher::Error::WatchError(_) => "WatchError",
+                            watcher::Error::WatchFailed(_) => "WatchFailed",
+                            watcher::Error::NoResourceVersion => "NoResourceVersion",
+                            watcher::Error::TooManyObjects => "TooManyObjects",
+                        };
+                        let error_labels = ResourceWatchErrorLabels {
+                            kind: labels.kind.clone(),
+                            group: labels.group.clone(),
+                            version: labels.version.clone(),
+                            error: error.into(),
+                        };
+                        metrics.watch_errors.get_or_create(&error_labels).inc();
+                    }
+                };
+            }
+            event
+        })
+    }
+}


### PR DESCRIPTION
We add a `with_metrics` method to the kubert runtime builder which causes the runtime to create counters for resource watch events.  This is only available if the "prometheus-client" feature is enabled.

```
# HELP kubert_resource_watch_applies Count of apply events for a resource watch.
# TYPE kubert_resource_watch_applies counter
kubert_resource_watch_applies_total{kind="Pod",group="",version="v1"} 45
kubert_resource_watch_applies_total{kind="HTTPRoute",group="gateway.networking.k8s.io",version="v1beta1"} 376
kubert_resource_watch_applies_total{kind="Service",group="",version="v1"} 3
# HELP kubert_resource_watch_restarts Count of restart events for a resource watch.
# TYPE kubert_resource_watch_restarts counter
kubert_resource_watch_restarts_total{kind="HTTPRoute",group="policy.linkerd.io",version="v1beta3"} 1
kubert_resource_watch_restarts_total{kind="ExternalWorkload",group="workload.linkerd.io",version="v1beta1"} 1
kubert_resource_watch_restarts_total{kind="ServerAuthorization",group="policy.linkerd.io",version="v1beta1"} 1
kubert_resource_watch_restarts_total{kind="Server",group="policy.linkerd.io",version="v1beta2"} 1
kubert_resource_watch_restarts_total{kind="HTTPRoute",group="gateway.networking.k8s.io",version="v1beta1"} 1
kubert_resource_watch_restarts_total{kind="Service",group="",version="v1"} 1
kubert_resource_watch_restarts_total{kind="Pod",group="",version="v1"} 1
kubert_resource_watch_restarts_total{kind="MeshTLSAuthentication",group="policy.linkerd.io",version="v1alpha1"} 1
kubert_resource_watch_restarts_total{kind="AuthorizationPolicy",group="policy.linkerd.io",version="v1alpha1"} 1
kubert_resource_watch_restarts_total{kind="NetworkAuthentication",group="policy.linkerd.io",version="v1alpha1"} 1
# HELP kubert_resource_watch_deletes Count of delete events for a resource watch.
# TYPE kubert_resource_watch_deletes counter
kubert_resource_watch_deletes_total{kind="HTTPRoute",group="gateway.networking.k8s.io",version="v1beta1"} 600
kubert_resource_watch_deletes_total{kind="Pod",group="",version="v1"} 5
kubert_resource_watch_deletes_total{kind="Server",group="policy.linkerd.io",version="v1beta2"} 1
kubert_resource_watch_deletes_total{kind="Service",group="",version="v1"} 2
# HELP kubert_resource_watch_errors Count of errors for a resource watch.
# TYPE kubert_resource_watch_errors counte
```