### PR TITLE
🦀 chore: fix build errors for 1.80 toolchain

### DIFF
--- a/kubert-prometheus-tokio/Cargo.toml
+++ b/kubert-prometheus-tokio/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["prometheus-client", "tokio", "metrics", "monitoring"]
 [features]
 rt = ["tokio/rt", "tokio/time", "tokio-metrics/rt"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
 [dependencies]
 prometheus-client = "0.22"
 tokio = "1"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -144,6 +144,9 @@ features = [
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
 [dependencies]
 ahash = { version = "0.8", optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }

--- a/kubert/src/initialized.rs
+++ b/kubert/src/initialized.rs
@@ -22,7 +22,7 @@ pub struct Initialized {
 /// Signals a component has been initialized
 #[derive(Debug)]
 #[must_use]
-pub struct Handle(OwnedSemaphorePermit);
+pub struct Handle(#[allow(dead_code)] OwnedSemaphorePermit);
 
 pin_project_lite::pin_project! {
     /// A wrapper that releases a `Handle` when the underlying `Future` or `Stream` becomes ready


### PR DESCRIPTION
this branch contains two small patches, to facilitate building this project
with the current stable Rust toolchain.

### chore: `lints.rust` allows `cfg(tokio_unstable)`

building `kubert` with Rust 1.80 or later will fail, with an error
shaped like this:

```text
error: unexpected `cfg` condition name: `tokio_unstable`
  --> kubert-prometheus-tokio/src/lib.rs:13:27
   |
13 | #[cfg(all(feature = "rt", tokio_unstable))]
   |                           ^^^^^^^^^^^^^^
   |
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(tokio_unstable)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

error: could not compile `kubert-prometheus-tokio` (lib) due to 3 previous errors
```

see the announcement here, from the Cargo team, as of
nightly-2024-05-05:
<https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs>

this commit adds a `[lints.rust]` entry adding the `tokio_unstable` flag
to the list of expected cfg's.

### chore: mute dead code warnings on handle permit

the `Handle` type wraps an inner semaphore permit. it is never read,
because simply _holding_ such a permit is itself semantically meaningful.

this does, however, cause a warning when compiled in Rust 1.80:

```text
error: field `0` is never read
  --> kubert/src/initialized.rs:25:19
   |
25 | pub struct Handle(OwnedSemaphorePermit);
   |            ------ ^^^^^^^^^^^^^^^^^^^^
   |            |
   |            field in this struct
   |
   = note: `Handle` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
```

this commit introduces a `#[allow(dead_code)]` directive on that inner
field, to address this warning and indicate explicitly that this field
is never read.