### PR TITLE
📝 chore: fix typo in `rt::Runtime` doc comment

### DIFF
--- a/kubert-prometheus-tokio/src/lib.rs
+++ b/kubert-prometheus-tokio/src/lib.rs
@@ -25,7 +25,7 @@ mod rt {
     /// enabled via the `tokio_unstable` feature. When it is not enabled, no metrics
     /// will be registered.
     ///
-    /// `RUSTFLAGS="--cfg tokio_unstable"` must be set at build-time to use this featur
+    /// `RUSTFLAGS="--cfg tokio_unstable"` must be set at build-time to use this feature.
     #[derive(Debug)]
     pub struct Runtime {
         runtime: tokio::runtime::Handle,


### PR DESCRIPTION
i noticed a sentence fragment while paging through the `kubert-prometheus-tokio` crate. this commit fixes that.