### PR TITLE
chore(kubert): v0.22.0

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,14 @@ ignore = []
 
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT"]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+]
 deny = []
 copyleft = "deny"
 allow-osi-fsf-free = "neither"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.21.2"
+version = "0.22.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."


### PR DESCRIPTION
This release changes the lease::Error type to include a timeout variant.