### PR TITLE
build(deps): bump linkerd/dev from v43 to v44

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "kubert",
-	"image": "ghcr.io/linkerd/dev:v43",
+	"image": "ghcr.io/linkerd/dev:v44",
 	"runArgs": [
 		"--init",
 		// Use the host network so we can access k3d, etc.

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -43,8 +43,8 @@ jobs:
     env:
       KUBERT_TEST_CLUSTER_VERSION: ${{ matrix.k8s }}
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
-      - uses: linkerd/dev/actions/setup-rust@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-rust@v44
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
       - run: just fetch
@@ -78,8 +78,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       KUBERT_TEST_CLUSTER_VERSION: ${{ matrix.k8s }}
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
-      - uses: linkerd/dev/actions/setup-rust@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-rust@v44
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - run: just --set features ${{ matrix.tls }} build-examples-image
       - run: just --set features ${{ matrix.tls }} test-cluster-create

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -32,12 +32,12 @@ jobs:
       matrix:
         rust:
           - "1.74"
-          - "1.76"
+          - "1.83"
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v43
-      - uses: linkerd/dev/actions/setup-rust@v43
+      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-rust@v44
         with:
           version: ${{ matrix.rust }}
           components: clippy
@@ -72,7 +72,7 @@ jobs:
           - shutdown
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
   fmt:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - run: just fmt-check
@@ -37,7 +37,7 @@ jobs:
   doc:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab

--- a/.github/workflows/release-prometheus-process.yml
+++ b/.github/workflows/release-prometheus-process.yml
@@ -30,7 +30,7 @@ jobs:
   meta:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: meta
@@ -76,7 +76,7 @@ jobs:
     needs: [meta, release]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - run: cargo publish --package=kubert-prometheus-process --dry-run

--- a/.github/workflows/release-prometheus-tokio.yml
+++ b/.github/workflows/release-prometheus-tokio.yml
@@ -30,7 +30,7 @@ jobs:
   meta:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: meta
@@ -76,7 +76,7 @@ jobs:
     needs: [meta, release]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     env:
       RUSTFLAGS: '--cfg tokio_unstable'
       RUSTDOCFLAGS: '--cfg tokio_unstable'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   meta:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: meta
@@ -75,7 +75,7 @@ jobs:
     needs: [meta, release]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     env:
       RUSTFLAGS: '--cfg tokio_unstable'
       RUSTDOCFLAGS: '--cfg tokio_unstable'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v43-rust
+    container: ghcr.io/linkerd/dev:v44-rust
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab

--- a/deny.toml
+++ b/deny.toml
@@ -1,14 +1,13 @@
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "deny"
-notice = "warn"
-ignore = []
+ignore = [
+    # Pending kube update
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0388",
+]
 
 [licenses]
-unlicensed = "deny"
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
@@ -17,10 +16,6 @@ allow = [
     "MIT",
     "Unicode-3.0",
 ]
-deny = []
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 exceptions = [
     { allow = [
@@ -59,9 +54,6 @@ skip = [
     # `rustls-pemfile` and `k8s-openapi` depend on versions of `base64` that
     # have diverged significantly.
     { name = "base64" },
-    # the current versions of `hyper` and `tokio` depend on semver-incompatible
-    # versions of `socket2` (0.4 and 0.5, respectively).
-    { name = "socket2" },
 ]
 skip-tree = [
     { name = "windows-sys" },

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linkerd/dev:v43-rust as build
+FROM ghcr.io/linkerd/dev:v44-rust as build
 WORKDIR /kubert
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -48,7 +48,7 @@ impl Prometheus {
     fn encode_body(&self, gzip: bool) -> std::result::Result<hyper::Body, std::fmt::Error> {
         if gzip {
             struct GzFmt<'a>(&'a mut deflate::write::GzEncoder<Vec<u8>>);
-            impl<'a> std::fmt::Write for GzFmt<'a> {
+            impl std::fmt::Write for GzFmt<'_> {
                 fn write_str(&mut self, s: &str) -> std::fmt::Result {
                     use std::io::Write as _;
                     self.0.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -14,6 +14,11 @@
 //! which does not require either particular TLS implementation, so that the
 //! top-level binary crate may choose which TLS implementation is used.
 
+#![cfg_attr(
+    not(any(feature = "rustls-tls", feature = "openssl-tls")),
+    allow(dead_code)
+)]
+
 use std::{convert::Infallible, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
@@ -135,10 +140,6 @@ pub struct TlsCertPath(PathBuf);
 
 #[derive(Clone, Debug)]
 // TLS paths may not be used if TLS is not enabled.
-#[cfg_attr(
-    not(any(feature = "rustls-tls", feature = "openssl-tls")),
-    allow(dead_code)
-)]
 struct TlsPaths {
     key: TlsKeyPath,
     certs: TlsCertPath,


### PR DESCRIPTION
* docker.io/library/golang from 1.22 to 1.23
* gotestsum from 0.4.2 to 1.12.0
* protoc-gen-go from 1.28.1 to 1.35.2
* protoc-gen-go-grpc from 1.2 to 1.5.1
* docker.io/library/rust from 1.76.0 to 1.83.0
* cargo-deny from 0.14.11 to 0.16.3
* cargo-nextest from 0.9.67 to 0.9.85
* cargo-tarpaulin from 0.27.3 to 0.31.3
* just from 1.24.0 to 1.37.0
* yq from 4.33.3 to 4.44.5
* markdownlint-cli2 from 0.10.0 to 0.15.0
* shellcheck from 0.9.0 to 0.10.0
* actionlint from 1.6.26 to 1.7.4
* protoc from 3.20.3 to 29.0
* step from 0.25.2 to 0.28.2
* kubectl from 1.29.2 to 1.31.3
* k3d from 5.6.0 to 5.7.5
* k3s image shas
* helm from 3.14.1 to 3.16.3
* helm-docs from 1.12.0 to 1.14.2