### PR TITLE
chore(cargo): move core/public dependencies to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,20 @@ members = [
     "kubert-prometheus-tokio",
     "examples",
 ]
+
+[workspace.dependencies]
+
+clap = { version = "4", default-features = false }
+
+hyper = { version = "0.14.17", default-features = false }
+
+k8s-openapi = { version = "0.20", default-features = false }
+
+kube-client = { version = "0.87.1", default-features = false }
+kube-core = { version = "0.87.1", default-features = false }
+kube-runtime = { version = "0.87.1", default-features = false }
+kube = { version = "0.87.1", default-features = false }
+
+prometheus-client = { version = "0.22.0", default-features = false }
+
+tokio = { version = "1.17.0", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,8 @@ skip-tree = [
     # `rcgen` is a test-only dependency, it's not a huge deal if it introduces
     # duplicate deps, as they won't be present in real life.
     { name = "rcgen" },
+    # Until thiserror v2 is widely used.
+    { name = "thiserror", version = "1" },
 ]
 
 [sources]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,22 +37,19 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter"] }
 
 [dev-dependencies.clap]
-version = "4"
-default-features = false
+workspace = true
 features = ["derive", "help", "env", "std"]
 
 [dev-dependencies.k8s-openapi]
-version = "0.20"
-default-features = false
+workspace = true
 features = ["latest"]
 
 [dev-dependencies.kube]
-version = "0.87.1"
-default-features = false
+workspace = true
 features = ["client", "derive", "rustls-tls", "runtime"]
 
 [dev-dependencies.tokio]
-version = "1"
+workspace = true
 features = ["macros", "parking_lot", "rt", "rt-multi-thread", "time"]
 
 [[example]]

--- a/kubert-prometheus-process/Cargo.toml
+++ b/kubert-prometheus-process/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.74"
 keywords = ["prometheus-client", "process", "metrics", "monitoring"]
 
 [dependencies]
-prometheus-client = "0.22.0"
+prometheus-client = { workspace = true }
 tracing = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/kubert-prometheus-tokio/Cargo.toml
+++ b/kubert-prometheus-tokio/Cargo.toml
@@ -16,7 +16,7 @@ rt = ["tokio/rt", "tokio/time", "tokio-metrics/rt"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [dependencies]
-prometheus-client = "0.22"
-tokio = "1"
+prometheus-client = { workspace = true }
+tokio = { workspace = true }
 tokio-metrics = "0.3"
 tracing = "0.1"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -158,19 +158,18 @@ drain = { version = "0.1.1", optional = true, default-features = false }
 chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
-hyper = { version = "0.14.17", optional = true, default-features = false }
+hyper = { workspace = true, optional = true, default-features = false }
 hyper-openssl = { version = "0.9.2", optional = true }
-kubert-prometheus-process = { version = "0.1.0", path = "../kubert-prometheus-process", optional = true }
 once_cell = { version = "1", optional = true }
 openssl = { version = "0.10.57", optional = true, default-features = false }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
-prometheus-client = { version = "0.22.0", optional = true, default-features = false }
+prometheus-client = { workspace = true, optional = true }
 rustls-pemfile = { version = "1", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-tokio = { version = "1.17.0", optional = false, default-features = false }
+tokio = { workspace = true, optional = false, default-features = false }
 tokio-rustls = { version = "0.24.1", optional = true, default-features = false }
 tokio-openssl = { version = "0.6.3", optional = true }
 tokio-util = { version = "0.7", optional = true, default-features = false }
@@ -179,6 +178,8 @@ tower-http = { version = "0.4.0", optional = true, default-features = false, fea
 ] }
 tower = { version = "0.4", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
+
+kubert-prometheus-process = { version = "0.1.0", path = "../kubert-prometheus-process", optional = true }
 
 [dependencies.clap]
 version = "4"
@@ -189,25 +190,21 @@ features = ["derive", "std"]
 # Not used directly, but required to ensure that the k8s-openapi dependency is considered part of
 # the "deps" graph rather than just the "dev-deps" graph
 [dependencies.k8s-openapi]
-version = "0.20"
+workspace = true
 optional = true
-default-features = false
 
 [dependencies.kube-client]
-version = "0.87.1"
+workspace = true
 optional = true
-default-features = false
 features = ["client", "config"]
 
 [dependencies.kube-core]
-version = "0.87.1"
+workspace = true
 optional = true
-default-features = false
 
 [dependencies.kube-runtime]
 version = "0.87.1"
 optional = true
-default-features = false
 
 [dependencies.tracing-subscriber]
 version = "0.3.9"
@@ -224,7 +221,7 @@ features = ["rt"]
 # === Dev ===
 
 [dev-dependencies]
-kube = { version = "0.87.1", default-features = false, features = ["runtime"] }
+kube = { workspace = true, features = ["runtime"] }
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }


### PR DESCRIPTION
To make it easier to manage dependencies across the workspace, this changes moves the core dependencies to the workspace level.