### PR TITLE
build(deps): update kube to 0.97.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ clap = { version = "4", default-features = false }
 
 hyper = { version = "0.14.17", default-features = false }
 
-k8s-openapi = { version = "0.20", default-features = false }
+k8s-openapi = { version = "0.23", default-features = false }
 
-kube-client = { version = "0.87.1", default-features = false }
-kube-core = { version = "0.87.1", default-features = false }
-kube-runtime = { version = "0.87.1", default-features = false }
-kube = { version = "0.87.1", default-features = false }
+kube-client = { version = "0.97", default-features = false }
+kube-core = { version = "0.97", default-features = false }
+kube-runtime = { version = "0.97", default-features = false }
+kube = { version = "0.97", default-features = false }
 
 prometheus-client = { version = "0.22.0", default-features = false }
 

--- a/deny.toml
+++ b/deny.toml
@@ -2,9 +2,8 @@
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    # Pending kube update
+    # kube-runtime uses backoff uses instant which is unmaintained.
     "RUSTSEC-2024-0384",
-    "RUSTSEC-2024-0388",
 ]
 
 [licenses]
@@ -15,6 +14,7 @@ allow = [
     "ISC",
     "MIT",
     "Unicode-3.0",
+    "Zlib",
 ]
 confidence-threshold = 0.8
 exceptions = [
@@ -23,20 +23,6 @@ exceptions = [
         "MIT",
         "OpenSSL",
     ], name = "ring", version = "*" },
-
-    # The Unicode-DFS--2016 license is necessary for unicode-ident because they
-    # use data from the unicode tables to generate the tables which are
-    # included in the application. We do not distribute those data files so
-    # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
-    # for more details.
-    { allow = [
-        "MIT",
-        "Apache-2.0",
-        "Unicode-DFS-2016",
-    ], name = "unicode-ident" },
-    { allow = [
-        "Zlib",
-    ], name = "adler32" },
 ]
 
 [[licenses.clarify]]
@@ -46,15 +32,6 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [bans]
-multiple-versions = "deny"
-wildcards = "allow"
-highlight = "all"
-deny = []
-skip = [
-    # `rustls-pemfile` and `k8s-openapi` depend on versions of `base64` that
-    # have diverged significantly.
-    { name = "base64" },
-]
 skip-tree = [
     { name = "windows-sys" },
     { name = "windows_aarch64_msvc" },
@@ -80,6 +57,11 @@ skip-tree = [
     { name = "rcgen" },
     # Until thiserror v2 is widely used.
     { name = "thiserror", version = "1" },
+    # TODO(ver): Rustls upgrade
+    { name = "tokio-rustls", version = "0.24" },
+    { name = "rustls-pemfile", version = "1" },
+    # TODO(ver): hyper upgrade
+    { name = "hyper", version = "0.14" },
 ]
 
 [sources]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -173,10 +173,10 @@ tokio = { workspace = true, optional = false, default-features = false }
 tokio-rustls = { version = "0.24.1", optional = true, default-features = false }
 tokio-openssl = { version = "0.6.3", optional = true }
 tokio-util = { version = "0.7", optional = true, default-features = false }
-tower-http = { version = "0.4.0", optional = true, default-features = false, features = [
+tower-http = { version = "0.6.0", optional = true, default-features = false, features = [
     "map-response-body",
 ] }
-tower = { version = "0.4", default-features = false, optional = true }
+tower = { version = "0.5", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
 kubert-prometheus-process = { version = "0.1.0", path = "../kubert-prometheus-process", optional = true }

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -203,7 +203,7 @@ workspace = true
 optional = true
 
 [dependencies.kube-runtime]
-version = "0.87.1"
+workspace = true
 optional = true
 
 [dependencies.tracing-subscriber]
@@ -222,20 +222,16 @@ features = ["rt"]
 
 [dev-dependencies]
 kube = { workspace = true, features = ["runtime"] }
+rcgen = { version = "0.12.0" }
+tempfile = "3.8"
 tokio-stream = "0.1"
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }
-# used for generating TLS certificates in the server tests.
-rcgen = { version = "0.12.0" }
-# used for creating temporary dirs for TLS certificates in the server tests.
-tempfile = "3.8"
 
 [dev-dependencies.k8s-openapi]
-version = "0.20"
-default-features = false
+workspace = true
 features = ["latest"]
 
 [dev-dependencies.tokio]
-version = "1.18"
-default-features = false
+workspace = true
 features = ["macros", "test-util"]

--- a/kubert/src/runtime/metrics.rs
+++ b/kubert/src/runtime/metrics.rs
@@ -100,13 +100,14 @@ impl ResourceWatchMetrics {
         watch.map(move |event| {
             if let Some(metrics) = &metrics {
                 match event {
-                    Ok(watcher::Event::Restarted(_)) => {
+                    Ok(watcher::Event::Init | watcher::Event::InitApply(_)) => {}
+                    Ok(watcher::Event::InitDone) => {
                         metrics.watch_events.get_or_create(&restart_labels).inc();
                     }
-                    Ok(watcher::Event::Applied(_)) => {
+                    Ok(watcher::Event::Apply(_)) => {
                         metrics.watch_events.get_or_create(&apply_labels).inc();
                     }
-                    Ok(watcher::Event::Deleted(_)) => {
+                    Ok(watcher::Event::Delete(_)) => {
                         metrics.watch_events.get_or_create(&delete_labels).inc();
                     }
                     Err(ref e) => {
@@ -117,7 +118,6 @@ impl ResourceWatchMetrics {
                                 watcher::Error::WatchError(_) => "WatchError",
                                 watcher::Error::WatchFailed(_) => "WatchFailed",
                                 watcher::Error::NoResourceVersion => "NoResourceVersion",
-                                watcher::Error::TooManyObjects => "TooManyObjects",
                             },
                             ..error_labels.clone()
                         };


### PR DESCRIPTION
New versions of kube require k8s-openapi v0.23.

The kubert index implementation has been updated to use the new watcher API.