### PR TITLE
chore: cleanup deny warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -57,8 +57,7 @@ skip-tree = [
     { name = "rcgen" },
     # Until thiserror v2 is widely used.
     { name = "thiserror", version = "1" },
-    # TODO(ver): Rustls upgrade
-    { name = "tokio-rustls", version = "0.24" },
+    # TODO(ver): Rustls-pemfile upgrade
     { name = "rustls-pemfile", version = "1" },
     # TODO(ver): hyper upgrade
     { name = "hyper", version = "0.14" },

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ export RUSTDOCFLAGS := env_var_or_default('RUSTDOCFLAGS', '--cfg tokio_unstable'
 # Run all tests and build the proxy
 default: fetch test build
 
-lint: md-lint fmt-check clippy doc
+lint: md-lint fmt-check clippy doc deny
 
 md-lint:
     just-md lint '**/*.md' '!**/target'
@@ -38,6 +38,9 @@ clippy *args:
 
 doc:
     @just-cargo doc -p kubert --no-deps --all-features --features=k8s-openapi/latest
+
+deny:
+    cargo-deny {{ _features }} check
 
 fmt:
     @just-cargo fmt


### PR DESCRIPTION
This change adds a `just deny` helper to make it easier to run cargo-deny with all features enabled.

The old version of tokio-rustls is removed from the deny.toml exceptions.