### PR TITLE
ci(examples): avoid flakiness by removing --frozen

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,13 +1,15 @@
 FROM ghcr.io/linkerd/dev:v44-rust as build
 WORKDIR /kubert
 COPY . .
+ENV CARGO_NET_RETRY=10 \
+    CARGO_INCREMENTAL=0 \
+    RUSTFLAGS="--cfg tokio_unstable"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    CARGO_NET_RETRY=10 just-cargo fetch
+    just-cargo fetch
 ARG FEATURES="rustls-tls"
-ENV RUSTFLAGS="--cfg tokio_unstable"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    CARGO_INCREMENTAL=0 just-cargo build \
-    --frozen --package=kubert-examples --examples \
+    just-cargo build \
+    --package=kubert-examples --examples \
     --no-default-features --features=${FEATURES}
 
 FROM gcr.io/distroless/cc-debian12:debug


### PR DESCRIPTION
There's some build flakiness where the build step fails because of the --frozen flag. This is unexpected because we have previously fetched the dependencies.

To avoid these failures, this change removes the --frozen flag from the build.