### PR TITLE
chore: remove .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]
-rustdocflags = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
The .cargo/config.toml makes it impossible to build the project without tokio_unstable. This is undesirable, so we remove it.