### PR TITLE
feat(admin)!: support compression on all HTTP endpoints

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,13 @@ openssl-tls = ["kubert/openssl-tls", "openssl"]
 [dependencies.kubert]
 path = "../kubert"
 default-features = false
-features = ["clap", "lease", "prometheus-client", "runtime"]
+features = [
+    "clap",
+    "lease",
+    "prometheus-client",
+    "runtime",
+    "runtime-brotli",
+]
 
 [dependencies.openssl]
 version = "0.10.57"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -33,15 +33,21 @@ admin = [
     "tokio/sync",
     "tracing",
 ]
+admin-brotli = ["tower-http/compression-br"]
+admin-gzip = ["tower-http/compression-gzip"]
+admin-compression = ["admin-brotli", "admin-gzip"]
 client = [
     "bytes",
     "kube-client",
     "thiserror",
     "tower",
     "tower/util",
-    "tower-http",
+    "tower-http/map-response-body",
     "hyper",
 ]
+client-brotli = ["tower-http/decompression-br"]
+client-gzip = ["tower-http/decompression-gzip"]
+client-decompression = ["client-brotli", "client-gzip"]
 errors = [
     "futures-core",
     "futures-util",
@@ -49,7 +55,6 @@ errors = [
     "tokio/time",
     "tracing",
 ]
-gzip = ["tower-http?/decompression-gzip"]
 index = [
     "ahash",
     "futures-core",
@@ -101,6 +106,9 @@ runtime = [
     "thiserror",
     "tracing",
 ]
+runtime-brotli = ["admin-brotli", "client-brotli"]
+runtime-gzip = ["admin-gzip", "client-gzip"]
+runtime-compression = ["admin-compression", "client-decompression"]
 server = [
     "drain",
     "hyper/http1",
@@ -119,6 +127,9 @@ server = [
     "tower",
     "tracing",
 ]
+server-brotli = ["tower-http/compression-br", "tower-http/decompression-br"]
+server-gzip = ["tower-http/compression-gzip", "tower-http/decompression-gzip"]
+server-compression = ["server-brotli", "server-gzip"]
 shutdown = [
     "drain",
     "futures-core",
@@ -180,9 +191,7 @@ tokio = { workspace = true, optional = false, default-features = false }
 tokio-rustls = { version = "0.26.1", optional = true, default-features = false }
 tokio-openssl = { version = "0.6.3", optional = true }
 tokio-util = { version = "0.7", optional = true, default-features = false }
-tower-http = { version = "0.6.0", optional = true, default-features = false, features = [
-    "map-response-body",
-] }
+tower-http = { version = "0.6.0", optional = true, default-features = false }
 tower = { version = "0.5", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -23,8 +23,7 @@ impl Prometheus {
                 .unwrap();
         }
 
-        let gzip = accepts_gzip(req.headers());
-        let body = match self.encode_body(gzip) {
+        let body = match self.encode_body() {
             Ok(body) => body,
             Err(error) => {
                 tracing::error!(%error, "Failed to encode metrics");
@@ -35,47 +34,18 @@ impl Prometheus {
             }
         };
 
-        let mut rsp = Response::builder().status(hyper::StatusCode::OK).header(
-            header::CONTENT_TYPE,
-            "application/openmetrics-text; version=1.0.0; charset=utf-8",
-        );
-        if gzip {
-            rsp = rsp.header(header::CONTENT_ENCODING, "gzip");
-        }
-        rsp.body(body).expect("response must be valid")
+        const OPENMETRICS_CONTENT_TYPE: &str =
+            "application/openmetrics-text; version=1.0.0; charset=utf-8";
+        Response::builder()
+            .status(hyper::StatusCode::OK)
+            .header(header::CONTENT_TYPE, OPENMETRICS_CONTENT_TYPE)
+            .body(body)
+            .expect("response must be valid")
     }
 
-    fn encode_body(&self, gzip: bool) -> std::result::Result<super::Body, std::fmt::Error> {
-        if gzip {
-            struct GzFmt<'a>(&'a mut deflate::write::GzEncoder<Vec<u8>>);
-            impl std::fmt::Write for GzFmt<'_> {
-                fn write_str(&mut self, s: &str) -> std::fmt::Result {
-                    use std::io::Write as _;
-                    self.0.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)
-                }
-            }
-
-            let mut gz = deflate::write::GzEncoder::new(vec![], deflate::Compression::Fast);
-            prometheus_client::encoding::text::encode(&mut GzFmt(&mut gz), &self.registry)?;
-            let buf = gz.finish().map_err(|_| std::fmt::Error)?;
-            return Ok(super::Body::new(buf.into()));
-        }
-
-        let mut buf = String::new();
+    fn encode_body(&self) -> std::result::Result<super::Body, std::fmt::Error> {
+        let mut buf = String::with_capacity(16 * 1024);
         prometheus_client::encoding::text::encode(&mut buf, &self.registry)?;
         Ok(super::Body::new(buf.into()))
     }
-}
-
-fn accepts_gzip(headers: &header::HeaderMap) -> bool {
-    headers
-        .get_all(header::ACCEPT_ENCODING)
-        .iter()
-        .any(|value| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| value.contains("gzip"))
-                .unwrap_or(false)
-        })
 }

--- a/kubert/src/server.rs
+++ b/kubert/src/server.rs
@@ -345,6 +345,11 @@ where
         }
     }
 
+    #[cfg(any(feature = "server-brotli", feature = "server-gzip"))]
+    let service = tower_http::decompression::Decompression::new(
+        tower_http::compression::Compression::new(service),
+    );
+
     // Serve the HTTP connection and wait for the drain signal. If a drain is
     // signaled, tell the HTTP connection to terminate gracefully when in-flight
     // requests have completed.


### PR DESCRIPTION
This change introduces support for brotli and gzip compression via the following features:

- admin-brotli
- admin-gzip
- client-brotli
- client-gzip
- server-brotli
- server-gzip

Additionally, convenience features have been added to enable both brotli and gzip compression on all HTTP endpoints:

- admin-compression
- client-decompression
- server-compression

And convenience features have been added to enable compression for the client and admin runtime:

- runtime-brotli
- runtime-gzip
- runtime-compression

BREAKING CHANGE: The 'gzip' feature has been removed.