### PR TITLE
chore(admin): cleanup admin router

### DIFF
--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 use hyper::header;
 
 #[derive(Clone, Debug)]
@@ -14,9 +13,9 @@ impl Prometheus {
         }
     }
 
-    pub(super) fn handle_metrics(&self, req: Request<hyper::body::Incoming>) -> Response<Body> {
+    pub(super) fn handle_metrics(&self, req: Request) -> Response {
         if !matches!(*req.method(), hyper::Method::GET | hyper::Method::HEAD) {
-            return Response::builder()
+            return hyper::Response::builder()
                 .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
                 .header(header::ALLOW, "GET, HEAD")
                 .body(Body::default())
@@ -27,7 +26,7 @@ impl Prometheus {
             Ok(body) => body,
             Err(error) => {
                 tracing::error!(%error, "Failed to encode metrics");
-                return Response::builder()
+                return hyper::Response::builder()
                     .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
                     .body(Body::default())
                     .unwrap();
@@ -36,7 +35,7 @@ impl Prometheus {
 
         const OPENMETRICS_CONTENT_TYPE: &str =
             "application/openmetrics-text; version=1.0.0; charset=utf-8";
-        Response::builder()
+        hyper::Response::builder()
             .status(hyper::StatusCode::OK)
             .header(header::CONTENT_TYPE, OPENMETRICS_CONTENT_TYPE)
             .body(body)


### PR DESCRIPTION
Before expanding the admin functionality with diagnostics, this change cleans up some of the type signatures. No functional changes.