### PR TITLE
feat(admin): add optional diagnostics endpoint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -197,7 +197,7 @@ jobs:
           - prometheus-client
           - requeue
           - runtime
-          - runtime,prometheus-client
+          - runtime,runtime-diagnostics,prometheus-client
           - server
           - server,rustls-tls
           - server,openssl-tls

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -70,7 +70,7 @@ lease = [
     "chrono",
     "futures-util",
     "hyper",
-    "k8s-openapi",
+    "dep:k8s-openapi",
     "kube-client",
     "kube-core",
     "serde",
@@ -105,6 +105,7 @@ runtime = [
     "thiserror",
     "tracing",
 ]
+runtime-diagnostics = ["dep:k8s-openapi"]
 runtime-brotli = ["admin-brotli", "client-brotli"]
 runtime-gzip = ["admin-gzip", "client-gzip"]
 runtime-compression = ["admin-compression", "client-decompression"]

--- a/kubert/src/admin.rs
+++ b/kubert/src/admin.rs
@@ -13,6 +13,12 @@ use std::{
 };
 use tracing::{debug, info_span, Instrument};
 
+#[cfg(feature = "runtime-diagnostics")]
+mod diagnostics;
+
+#[cfg(feature = "runtime-diagnostics")]
+pub(crate) use self::diagnostics::Diagnostics;
+
 /// An error binding an admin server.
 #[derive(Debug, thiserror::Error)]
 #[error("failed to bind admin server: {0}")]
@@ -44,6 +50,8 @@ pub struct Builder {
     addr: SocketAddr,
     ready: Readiness,
     routes: AHashMap<String, HandlerFn>,
+    #[cfg(feature = "runtime-diagnostics")]
+    diagnostics: Diagnostics,
 }
 
 /// Supports spawning an admin server
@@ -54,6 +62,8 @@ pub struct Bound {
     listener: tokio::net::TcpListener,
     server: hyper::server::conn::http1::Builder,
     routes: AHashMap<String, HandlerFn>,
+    #[cfg(feature = "runtime-diagnostics")]
+    diagnostics: Diagnostics,
 }
 
 /// Controls how the admin server advertises readiness
@@ -110,6 +120,8 @@ impl Builder {
             addr,
             ready: Readiness(Arc::new(false.into())),
             routes: Default::default(),
+            #[cfg(feature = "runtime-diagnostics")]
+            diagnostics: Diagnostics::new(),
         }
     }
 
@@ -204,6 +216,8 @@ impl Builder {
             addr,
             ready,
             routes,
+            #[cfg(feature = "runtime-diagnostics")]
+            diagnostics,
         } = self;
 
         let lis = std::net::TcpListener::bind(addr)?;
@@ -226,6 +240,8 @@ impl Builder {
             server,
             listener,
             routes,
+            #[cfg(feature = "runtime-diagnostics")]
+            diagnostics,
         })
     }
 }
@@ -260,11 +276,15 @@ impl Bound {
             listener,
             routes,
             addr,
+            #[cfg(feature = "runtime-diagnostics")]
+            diagnostics,
         } = self;
 
         let task = tokio::spawn({
             let ready = ready.clone();
             let routes = Arc::new(routes);
+            #[cfg(feature = "runtime-diagnostics")]
+            let diagnostics = diagnostics.clone();
             async move {
                 loop {
                     let (stream, client_addr) = match listener.accept().await {
@@ -283,8 +303,17 @@ impl Bound {
                         use tower::ServiceExt;
                         let ready = ready.clone();
                         let routes = routes.clone();
-                        let svc =
-                            tower::service_fn(move |req: Request| handle(&ready, &routes, req));
+                        #[cfg(feature = "runtime-diagnostics")]
+                        let diagnostics = diagnostics.clone();
+                        let svc = tower::service_fn(move |req: Request| {
+                            handle(
+                                &ready,
+                                &routes,
+                                req,
+                                #[cfg(feature = "runtime-diagnostics")]
+                                (client_addr, &diagnostics),
+                            )
+                        });
                         #[cfg(any(feature = "admin-brotli", feature = "admin-gzip"))]
                         let svc = tower_http::compression::Compression::new(svc);
                         hyper::service::service_fn(move |req| svc.clone().oneshot(req))
@@ -349,6 +378,10 @@ fn handle(
     ready: &Readiness,
     routes: &Arc<AHashMap<String, HandlerFn>>,
     req: Request,
+    #[cfg(feature = "runtime-diagnostics")] (client_addr, diagnostics): (
+        std::net::SocketAddr,
+        &Diagnostics,
+    ),
 ) -> Pin<
     Box<
         dyn std::future::Future<Output = Result<hyper::Response<Body>, tokio::task::JoinError>>
@@ -361,6 +394,11 @@ fn handle(
     }
     if req.uri().path() == "/ready" {
         return Box::pin(future::ok(handle_ready(ready, req)));
+    }
+
+    #[cfg(feature = "runtime-diagnostics")]
+    if req.uri().path() == "/kubert.json" {
+        return Box::pin(future::ok(diagnostics.handle(client_addr, req)));
     }
 
     if routes.contains_key(req.uri().path()) {

--- a/kubert/src/admin/diagnostics.rs
+++ b/kubert/src/admin/diagnostics.rs
@@ -1,0 +1,60 @@
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+use std::net::SocketAddr;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Diagnostics {
+    initial_time: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub(super) struct Summary {
+    initial_timestamp: Time,
+    current_timestamp: Time,
+}
+
+// === impl Diagnostics ===
+
+impl Diagnostics {
+    pub(super) fn new() -> Self {
+        Self {
+            initial_time: chrono::Utc::now(),
+        }
+    }
+
+    pub(super) fn handle(&self, client_addr: SocketAddr, req: super::Request) -> super::Response {
+        if req.method() != hyper::Method::GET {
+            return hyper::Response::builder()
+                .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
+                .header(hyper::header::ALLOW, "GET")
+                .body(super::Body::default())
+                .unwrap();
+        }
+
+        if !client_addr.ip().is_loopback() {
+            tracing::info!(client.ip=%client_addr.ip(), "Rejecting non-loopback request for diagnostics");
+            return hyper::Response::builder()
+                .status(hyper::StatusCode::FORBIDDEN)
+                .body(super::Body::default())
+                .unwrap();
+        }
+
+        let summary = Summary {
+            initial_timestamp: Time(self.initial_time),
+            current_timestamp: Time(chrono::Utc::now()),
+        };
+
+        let mut bytes = Vec::with_capacity(8 * 1024);
+        if let Err(error) = serde_json::to_writer_pretty(&mut bytes, &summary) {
+            tracing::error!(%error, "Failed to serialize runtime diagnostics");
+            return hyper::Response::builder()
+                .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
+                .body(super::Body::default())
+                .unwrap();
+        }
+
+        hyper::Response::builder()
+            .header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(super::Body::from(bytes))
+            .unwrap()
+    }
+}

--- a/kubert/src/admin/metrics.rs
+++ b/kubert/src/admin/metrics.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 use hyper::header;
 
 #[derive(Clone, Debug)]
@@ -14,9 +13,9 @@ impl Prometheus {
         }
     }
 
-    pub(super) fn handle_metrics(&self, req: Request<hyper::body::Incoming>) -> Response<Body> {
+    pub(super) fn handle_metrics(&self, req: Request) -> Response {
         if !matches!(*req.method(), hyper::Method::GET | hyper::Method::HEAD) {
-            return Response::builder()
+            return hyper::Response::builder()
                 .status(hyper::StatusCode::METHOD_NOT_ALLOWED)
                 .header(header::ALLOW, "GET, HEAD")
                 .body(Body::default())
@@ -27,7 +26,7 @@ impl Prometheus {
             Ok(body) => body,
             Err(error) => {
                 tracing::error!(%error, "Failed to encode metrics");
-                return Response::builder()
+                return hyper::Response::builder()
                     .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
                     .body(Body::default())
                     .unwrap();
@@ -36,7 +35,7 @@ impl Prometheus {
 
         const OPENMETRICS_CONTENT_TYPE: &str =
             "application/openmetrics-text; version=1.0.0; charset=utf-8";
-        Response::builder()
+        hyper::Response::builder()
             .status(hyper::StatusCode::OK)
             .header(header::CONTENT_TYPE, OPENMETRICS_CONTENT_TYPE)
             .body(body)

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -22,6 +22,7 @@
 //! - **runtime**: Enables the [`runtime`] module. Enabling this feature flag
 //!   also enables the **admin**, **client**, **initialized**, and **log**
 //!   features.
+//! - **runtime-diagnostics**: Enables the /kubert.json local admin endpoint.
 //! - **server**: Enables the [`server`] module, and server-related
 //!   functionality in the [`runtime`] module (if the **runtime** feature is
 //!   also enabled).


### PR DESCRIPTION
This change adds a new /kubert.json endpoint on the admin HTTP server. This endpoint returns a JSON object with various diagnostic information about the kubert runtime that do not readily fit into metrics. This admin endpoint is only available from the localhost and cannot be accessed from the non-loopback network.

The initial version of this endpoint includes only timestamp information. Additional diagnostic information will be added in future commits.