### PR TITLE
feat(runtime): add Runtime::spawn_lease

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -197,7 +197,9 @@ jobs:
           - prometheus-client
           - requeue
           - runtime
-          - runtime,runtime-diagnostics,prometheus-client
+          - runtime,lease
+          - runtime,runtime-diagnostics
+          - runtime,runtime-diagnostics,lease,prometheus-client
           - server
           - server,rustls-tls
           - server,openssl-tls

--- a/kubert/src/lib.rs
+++ b/kubert/src/lib.rs
@@ -131,7 +131,7 @@ pub use self::client::ClientArgs;
 pub use self::initialized::Initialized;
 
 #[cfg(feature = "lease")]
-pub use self::lease::LeaseManager;
+pub use self::lease::{LeaseManager, LeaseParams};
 
 #[cfg(feature = "log")]
 pub use self::log::{LogFilter, LogFormat, LogInitError};


### PR DESCRIPTION
Lease initialization is currently decoupled from the runtime, which makes it difficult to instrument diagnostics automatically.

In preparation for lease diagnostics, this change adds a new `Runtime::spawn_lease` method that configures a managed lease.