### PR TITLE
feat(server): default to using rustls-tls

### DIFF
--- a/kubert/src/server/tests.rs
+++ b/kubert/src/server/tests.rs
@@ -30,11 +30,22 @@ fn gen_keys() -> (TempDir, TlsPaths) {
     (dir, TlsPaths { key, certs })
 }
 
+#[cfg(feature = "rustls-tls")]
 #[tokio::test]
-async fn load_tls() {
+async fn load_tls_rustls() {
     let (_tempdir, TlsPaths { key, certs }) = gen_keys();
-    match super::tls::load_tls(&key, &certs).await {
-        Ok(_) => eprintln!("load_tls: success!"),
+    match super::tls_rustls::load_tls(&key, &certs).await {
+        Ok(_) => println!("load_tls: success!"),
+        Err(error) => panic!("load_tls failed! {error}"),
+    }
+}
+
+#[cfg(feature = "openssl-tls")]
+#[tokio::test]
+async fn load_tls_openssl() {
+    let (_tempdir, TlsPaths { key, certs }) = gen_keys();
+    match super::tls_openssl::load_tls(&key, &certs).await {
+        Ok(_) => println!("load_tls: success!"),
         Err(error) => panic!("load_tls failed! {error}"),
     }
 }


### PR DESCRIPTION
Both kube and kubert allow the rustls-tls and openssl-tls features simultaneously. However, their default behaviors differ, which causes clients and servers to use different TLS implementations when both features are enabled:

* kube clients use rustls-tls by default;
* kubert servers use openssl-tls by default.

This commit changes the default behavior of kubert servers to use rustls-tls when both features are enabled, aligning with [kube].

[kube]: https://github.com/kube-rs/kube/blob/6a980c6ea50f2f3f4f2867d3df3fd77be00fca84/kube-client/src/client/builder.rs#L157-L165