### PR TITLE
ci: skip redundant MSKV tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -224,6 +224,9 @@ jobs:
         tls:
           - openssl-tls
           - rustls-tls
+        exclude:
+          - k8s: v1.21
+            tls: openssl-tls
     timeout-minutes: 30 # building with OpenSSL can be quite slow...
     runs-on: ubuntu-24.04
     env:
@@ -259,6 +262,9 @@ jobs:
         tls:
           - openssl-tls
           - rustls-tls
+        exclude:
+          - k8s: v1.21
+            tls: openssl-tls
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     env:


### PR DESCRIPTION
There's no need to test multiple TLS implementations on multiple Kubernetes versions. This change simplifies CI by excluding openssl on the minimum kubernetes version.