### PR TITLE
feat(client): add a default response headers timeout

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -42,6 +42,7 @@ admin-gzip = ["tower-http/compression-gzip"]
 admin-compression = ["admin-brotli", "admin-gzip"]
 client = [
     "dep:bytes",
+    "dep:futures-util",
     "dep:hyper",
     "dep:kube-client",
     "dep:thiserror",

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -134,9 +134,14 @@ impl ClientArgs {
 }
 
 // Used by middlewares, e.g. timeouts.
-type BoxService = tower::util::BoxService<Request, Response, BoxError>;
-type Request = hyper::Request<kube_client::client::Body>;
-type Response = hyper::Response<BoxBody>;
-type BoxBody = Box<dyn hyper::body::Body<Data = bytes::Bytes, Error = BoxError> + Send + Unpin>;
-type BoxError = tower::BoxError;
-type BoxFuture = futures_util::future::BoxFuture<'static, Result<Response, BoxError>>;
+mod svc {
+    pub use tower::{layer::layer_fn, layer::Layer, Service};
+
+    pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+    pub type Request = hyper::Request<kube_client::client::Body>;
+    pub type Response = hyper::Response<BoxBody>;
+    pub type BoxBody =
+        Box<dyn hyper::body::Body<Data = bytes::Bytes, Error = BoxError> + Send + Unpin>;
+    pub type BoxError = tower::BoxError;
+    pub type BoxFuture = futures_util::future::BoxFuture<'static, Result<Response, BoxError>>;
+}

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -3,6 +3,8 @@ pub use kube_client::*;
 use std::path::PathBuf;
 use thiserror::Error;
 
+mod timeouts;
+
 /// Configures a Kubernetes client
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
@@ -129,105 +131,10 @@ impl ClientArgs {
     }
 }
 
+// Used by middlewares, e.g. timeouts.
 type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 type Request = hyper::Request<kube_client::client::Body>;
 type Response = hyper::Response<BoxBody>;
 type BoxBody = Box<dyn hyper::body::Body<Data = bytes::Bytes, Error = BoxError> + Send + Unpin>;
 type BoxError = tower::BoxError;
 type BoxFuture = futures_util::future::BoxFuture<'static, Result<Response, BoxError>>;
-
-mod timeouts {
-    use super::{BoxError, BoxFuture, BoxService, Request, Response};
-    use kube_client::core::Duration as KubeDuration;
-    use std::task::{Context, Poll};
-    use tokio::time;
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub struct ResponseHeaders(time::Duration);
-
-    #[derive(Debug, thiserror::Error)]
-    #[error("response headers timeout after {0:?}")]
-    pub struct ResponseHeadersTimeoutError(time::Duration);
-
-    #[derive(Debug)]
-    struct TimeoutService {
-        response_headers_timeout: time::Duration,
-        inner: BoxService,
-    }
-
-    pub fn layer(
-        ResponseHeaders(response_headers_timeout): ResponseHeaders,
-    ) -> impl tower::layer::Layer<BoxService, Service = BoxService> + Clone {
-        tower::layer::layer_fn(move |inner| {
-            BoxService::new(TimeoutService {
-                response_headers_timeout,
-                inner,
-            })
-        })
-    }
-
-    impl tower::Service<Request> for TimeoutService {
-        type Response = Response;
-        type Error = BoxError;
-        type Future = BoxFuture;
-
-        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            self.inner.poll_ready(cx).map_err(Into::into)
-        }
-
-        fn call(&mut self, req: Request) -> Self::Future {
-            let Self {
-                response_headers_timeout,
-                ref mut inner,
-            } = *self;
-            let call = time::timeout(response_headers_timeout, inner.call(req));
-            Box::pin(async move {
-                let rsp = call
-                    .await
-                    .map_err(|_| ResponseHeadersTimeoutError(response_headers_timeout))??;
-                // TODO request timeouts
-                Ok(rsp)
-            })
-        }
-    }
-
-    // === impl ResponseHeaders ===
-
-    impl ResponseHeaders {
-        // This default timeout is fairly arbitrary, but intended to be
-        // reasonably long enough that no legitimate API calls would be
-        // affected. The value of 9s is chose to differentiate it from other 10s
-        // timeouts in the system.
-        const DEFAULT: Self = Self(time::Duration::from_secs(9));
-    }
-
-    impl Default for ResponseHeaders {
-        fn default() -> Self {
-            Self::DEFAULT
-        }
-    }
-
-    impl std::str::FromStr for ResponseHeaders {
-        type Err = <KubeDuration as std::str::FromStr>::Err;
-
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            Ok(Self(s.parse::<KubeDuration>()?.into()))
-        }
-    }
-
-    impl std::fmt::Display for ResponseHeaders {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            KubeDuration::from(self.0).fmt(f)
-        }
-    }
-
-    #[cfg(test)]
-    #[test]
-    fn response_headers_roundtrip() {
-        let orig = "2h3m4s5ms".parse::<ResponseHeaders>().expect("valid");
-        assert_eq!(
-            orig.to_string().parse::<ResponseHeaders>().expect("valid"),
-            orig,
-        );
-    }
-}

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 
 mod timeouts;
 
+pub use self::timeouts::ResponseHeadersTimeout;
+
 /// Configures a Kubernetes client
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
@@ -37,9 +39,9 @@ pub struct ClientArgs {
     /// The timeout for response headers from the Kubernetes API.
     #[cfg_attr(feature = "clap", clap(
         long = "kube-api-response-headers-timeout",
-        default_value_t = timeouts::ResponseHeaders::default(),
+        default_value_t = ResponseHeadersTimeout::default(),
     ))]
-    pub response_headers_timeout: timeouts::ResponseHeaders,
+    pub response_headers_timeout: ResponseHeadersTimeout,
 }
 
 /// Indicates an error occurred while configuring the Kubernetes client

--- a/kubert/src/client/timeouts.rs
+++ b/kubert/src/client/timeouts.rs
@@ -1,0 +1,93 @@
+use super::{BoxError, BoxFuture, BoxService, Request, Response};
+use kube_client::core::Duration as KubeDuration;
+use std::task::{Context, Poll};
+use tokio::time;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResponseHeaders(time::Duration);
+
+#[derive(Debug, thiserror::Error)]
+#[error("response headers timeout after {0:?}")]
+pub struct ResponseHeadersTimeoutError(time::Duration);
+
+#[derive(Debug)]
+struct TimeoutService {
+    response_headers_timeout: time::Duration,
+    inner: BoxService,
+}
+
+pub fn layer(
+    ResponseHeaders(response_headers_timeout): ResponseHeaders,
+) -> impl tower::layer::Layer<BoxService, Service = BoxService> + Clone {
+    tower::layer::layer_fn(move |inner| {
+        BoxService::new(TimeoutService {
+            response_headers_timeout,
+            inner,
+        })
+    })
+}
+
+impl tower::Service<Request> for TimeoutService {
+    type Response = Response;
+    type Error = BoxError;
+    type Future = BoxFuture;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let Self {
+            response_headers_timeout,
+            ref mut inner,
+        } = *self;
+        let call = time::timeout(response_headers_timeout, inner.call(req));
+        Box::pin(async move {
+            let rsp = call
+                .await
+                .map_err(|_| ResponseHeadersTimeoutError(response_headers_timeout))??;
+            // TODO request timeouts
+            Ok(rsp)
+        })
+    }
+}
+
+// === impl ResponseHeaders ===
+
+impl ResponseHeaders {
+    // This default timeout is fairly arbitrary, but intended to be
+    // reasonably long enough that no legitimate API calls would be
+    // affected. The value of 9s is chose to differentiate it from other 10s
+    // timeouts in the system.
+    const DEFAULT: Self = Self(time::Duration::from_secs(9));
+}
+
+impl Default for ResponseHeaders {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl std::str::FromStr for ResponseHeaders {
+    type Err = <KubeDuration as std::str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse::<KubeDuration>()?.into()))
+    }
+}
+
+impl std::fmt::Display for ResponseHeaders {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        KubeDuration::from(self.0).fmt(f)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn response_headers_roundtrip() {
+    let orig = "2h3m4s5ms".parse::<ResponseHeaders>().expect("valid");
+    assert_eq!(
+        orig.to_string().parse::<ResponseHeaders>().expect("valid"),
+        orig,
+    );
+}

--- a/kubert/src/client/timeouts.rs
+++ b/kubert/src/client/timeouts.rs
@@ -1,4 +1,4 @@
-use super::{BoxError, BoxFuture, BoxService, Request, Response};
+use super::svc::{self, BoxError, BoxFuture, BoxService, Request, Response};
 use kube_client::core::Duration as KubeDuration;
 use std::task::{Context, Poll};
 use tokio::time;
@@ -19,8 +19,8 @@ struct TimeoutService {
 
 pub fn layer(
     ResponseHeadersTimeout(response_headers_timeout): ResponseHeadersTimeout,
-) -> impl tower::layer::Layer<BoxService, Service = BoxService> + Clone {
-    tower::layer::layer_fn(move |inner| {
+) -> impl svc::Layer<BoxService, Service = BoxService> + Clone {
+    svc::layer_fn(move |inner| {
         BoxService::new(TimeoutService {
             response_headers_timeout,
             inner,
@@ -28,7 +28,7 @@ pub fn layer(
     })
 }
 
-impl tower::Service<Request> for TimeoutService {
+impl svc::Service<Request> for TimeoutService {
     type Response = Response;
     type Error = BoxError;
     type Future = BoxFuture;


### PR DESCRIPTION
The underlying kube client does not enforce any request timeouts, relying on the server to implement them. But this means that calls--especially those dispatched by a watcher--may hang indefinitely waiting for an API server response.

This change introduces a default timeout for response headers, which is set to 10s. Furthermore, the ClientArgs type is used to expose this timeout configuration as a command-line option, kube-api-response-headers-timeout.