### PR TITLE
chore(client): introduce a ClientBuilder

### DIFF
--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -131,9 +131,7 @@ impl ClientArgs {
 impl ClientBuilder {
     /// Creates a new client builder from the given command-line arguments.
     pub fn from_args(args: ClientArgs) -> Self {
-        Self {
-            args,
-        }
+        Self { args }
     }
 
     /// Builds the Kubernetes client.

--- a/kubert/src/client.rs
+++ b/kubert/src/client.rs
@@ -33,6 +33,12 @@ pub struct ClientArgs {
     pub impersonate_group: Option<String>,
 }
 
+/// A builder for a Kubernetes client.
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
+pub struct ClientBuilder {
+    args: ClientArgs,
+}
+
 /// Indicates an error occurred while configuring the Kubernetes client
 #[derive(Debug, Error)]
 #[cfg_attr(docsrs, doc(cfg(feature = "client")))]
@@ -60,13 +66,7 @@ impl ClientArgs {
     /// This is basically equivalent to using `kube_client::Client::try_default`, except that it
     /// supports kubeconfig configuration from the command-line.
     pub async fn try_client(self) -> Result<Client, ConfigError> {
-        let client = match self.load_local_config().await {
-            Ok(client) => client,
-            Err(e) if self.is_customized() => return Err(e),
-            Err(_) => Config::incluster()?,
-        };
-
-        client.try_into().map_err(Into::into)
+        ClientBuilder::from_args(self).build().await
     }
 
     /// Indicates whether the command-line arguments attempt to customize the Kubernetes
@@ -78,6 +78,16 @@ impl ClientArgs {
             || self.impersonate_user.is_some()
             || self.impersonate_group.is_some()
             || self.kubeconfig.is_some()
+    }
+
+    /// Loads a local config if available, falling back to in-cluster config if
+    /// client args have not been specified.
+    async fn load_config(&self) -> Result<Config, ConfigError> {
+        match self.load_local_config().await {
+            Ok(config) => Ok(config),
+            Err(e) if self.is_customized() => Err(e),
+            Err(_) => Config::incluster().map_err(Into::into),
+        }
     }
 
     /// Loads a local (i.e. not in-cluster) Kubernetes client configuration
@@ -115,5 +125,23 @@ impl ClientArgs {
         Config::from_custom_kubeconfig(kubeconfig, &options)
             .await
             .map_err(Into::into)
+    }
+}
+
+impl ClientBuilder {
+    /// Creates a new client builder from the given command-line arguments.
+    pub fn from_args(args: ClientArgs) -> Self {
+        Self {
+            args,
+        }
+    }
+
+    /// Builds the Kubernetes client.
+    pub async fn build(self) -> Result<Client, ConfigError> {
+        let config = self.args.load_config().await?;
+
+        let cb = kube_client::client::ClientBuilder::try_from(config)?;
+
+        Ok(cb.build())
     }
 }


### PR DESCRIPTION
To prepare to instrument Kubernetes clients, this change introduces a basic ClientBuilder type.