### PR TITLE
fix(ci): remove EmbarkStudios/cargo-deny-action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -143,18 +143,14 @@ jobs:
     if: needs.changed.outputs.cargo == 'true' || needs.changed.outputs.deny == 'true' || needs.changed.outputs.build == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-    # Prevent sudden announcement of a new advisory from failing Ci.
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    container: ghcr.io/linkerd/dev:v45-rust
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - uses: EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868
-      with:
-        command: check ${{ matrix.checks }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3
+      - run: just fetch
+      - run: cargo deny --all-features check bans licenses sources
+      - run: cargo deny --all-features check advisories
+        continue-on-error: true
 
   kubert-check-all:
     needs: changed


### PR DESCRIPTION
cargo-deny-action is broken: EmbarkStudios/cargo-deny-action#91

This change replaces the action with a manual invocation via the dev container image.