### PR TITLE
chore: bump versions

### DIFF
--- a/kubert-prometheus-process/Cargo.toml
+++ b/kubert-prometheus-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert-prometheus-process"
-version = "0.2.0-alpha1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A prometheus-client process metrics collector"

--- a/kubert-prometheus-tokio/Cargo.toml
+++ b/kubert-prometheus-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert-prometheus-tokio"
-version = "0.2.0-alpha1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A prometheus-client tokio runtime metrics collector"

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubert"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."
@@ -211,7 +211,7 @@ tower-http = { version = "0.6.0", optional = true, default-features = false }
 tower = { version = "0.5", default-features = false, optional = true }
 tracing = { version = "0.1.31", optional = true }
 
-kubert-prometheus-process = { version = "0.2.0-alpha1", path = "../kubert-prometheus-process", optional = true }
+kubert-prometheus-process = { version = "0.2.0", path = "../kubert-prometheus-process", optional = true }
 
 [dependencies.clap]
 version = "4"
@@ -245,7 +245,7 @@ default-features = false
 features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"]
 
 [target.'cfg(tokio_unstable)'.dependencies.kubert-prometheus-tokio]
-version = "0.2.0-alpha1"
+version = "0.2.0"
 path = "../kubert-prometheus-tokio"
 optional = true
 features = ["rt"]


### PR DESCRIPTION
Drop alpha versions from kubert-prometheus-process, kubert-prometheus-tokio. Bump kubert to v0.23.1.