### PR TITLE
fix(tls): Migrate from `rustls-pemfile` to `rustls-pki-types`

### DIFF
--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["kubernetes", "client", "runtime", "server"]
 
 [features]
 _tls = [
-    "dep:rustls-pemfile",
+    "dep:rustls-pki-types",
     "dep:tokio-rustls",
     "kube-client?/rustls-tls",
 ]
@@ -194,7 +194,7 @@ once_cell = { version = "1", optional = true }
 parking_lot = { version = "0.12", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 prometheus-client = { workspace = true, optional = true }
-rustls-pemfile = { version = "2", optional = true }
+rustls-pki-types = { version = "1", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 sha2 = { version = "0.10", optional = true }

--- a/kubert/src/server/tls_rustls.rs
+++ b/kubert/src/server/tls_rustls.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rustls_pki_types::{pem::PemObject, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer};
 use std::sync::Arc;
 use tokio_rustls::{
     rustls::{
@@ -39,19 +40,23 @@ async fn load_certs(
     TlsCertPath(cp): &TlsCertPath,
 ) -> std::io::Result<Vec<CertificateDer<'static>>> {
     let pem = tokio::fs::read(cp).await?;
-    rustls_pemfile::certs(&mut pem.as_slice()).collect()
+    CertificateDer::pem_slice_iter(pem.as_slice())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(std::io::Error::other)
 }
 
 async fn load_private_key(TlsKeyPath(kp): &TlsKeyPath) -> std::io::Result<PrivateKeyDer<'static>> {
     let pem = tokio::fs::read(kp).await?;
 
-    let mut keys = rustls_pemfile::pkcs8_private_keys(&mut pem.as_slice())
+    let mut keys = PrivatePkcs8KeyDer::pem_slice_iter(pem.as_slice())
         .map(|res| res.map(PrivateKeyDer::from))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(std::io::Error::other)?;
     if keys.is_empty() {
-        keys = rustls_pemfile::rsa_private_keys(&mut pem.as_slice())
+        keys = PrivatePkcs1KeyDer::pem_slice_iter(pem.as_slice())
             .map(|res| res.map(PrivateKeyDer::from))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(std::io::Error::other)?;
     }
 
     let key = keys


### PR DESCRIPTION
`rustls-pemfile` is unmaintained and has been archived since Aug 2025 (see https://rustsec.org/advisories/RUSTSEC-2025-0134), leading to RUSTSEC audit errors downstream.

`rustls-pemfile` at this point is thin wrappers around the parsing logic in `rustls-pki-types`, so this does a direct translation to those APIs.

This also requires an MSRV bump from 1.85 to 1.88