### PR TITLE
chore(deps): Update k8s-openapi and kube-* dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", default-features = false }
 hyper = { version = "1", default-features = false }
 hyper-util = { version = "0.1", default-features = false }
 
-k8s-openapi = { version = "0.25", default-features = false }
+k8s-openapi = { version = "0.27", default-features = false }
 
-kube-client = { version = ">=1.1.0,<1.2.0", default-features = false }
-kube-core = { version = ">=1.1.0,<1.2.0", default-features = false }
-kube-runtime = { version = ">=1.1.0,<1.2.0", default-features = false }
-kube = { version = ">=1.1.0,<1.2.0", default-features = false }
+kube-client = { version = "3", default-features = false }
+kube-core = { version = "3", default-features = false }
+kube-runtime = { version = "3", default-features = false }
+kube = { version = "3", default-features = false }
 
 prometheus-client = { version = "0.24.0", default-features = false }
 

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -275,9 +275,8 @@ where
 
 fn print_claim(claim: &kubert::lease::Claim, identity: &str) {
     let holder = &claim.holder;
-    let expiry = claim
-        .expiry
-        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    // truncate to second precision
+    let expiry = format!("{:.0}", claim.expiry);
 
     if !claim.is_current() {
         println!("! Expired for {holder} at {expiry}");

--- a/examples/tests/lease.rs
+++ b/examples/tests/lease.rs
@@ -3,6 +3,7 @@
 use k8s_openapi::{
     api::coordination::v1 as coordv1,
     apimachinery::pkg::apis::meta::v1::{self as metav1},
+    jiff,
 };
 use kubert::LeaseManager;
 use maplit::{btreemap, convert_args};
@@ -12,10 +13,7 @@ type Api = kube::Api<coordv1::Lease>;
 
 macro_rules! assert_time_eq {
     ($a:expr, $b:expr $(,)?) => {
-        assert_eq!(
-            $a.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-            $b.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-        );
+        assert_eq!(format!("{:.3}", $a), format!("{:.3}", $b),);
     };
 }
 
@@ -42,7 +40,10 @@ async fn exclusive() {
     let lease1 = handle.init_new().await;
     let claim1 = lease1.ensure_claimed("bob", &params).await.expect("claim");
     assert_eq!(claim0.holder, claim1.holder);
-    assert_eq!(claim0.expiry.timestamp(), claim1.expiry.timestamp());
+    assert_eq!(
+        claim0.expiry.as_millisecond(),
+        claim1.expiry.as_millisecond()
+    );
     assert!(claim0.is_current_for("alice"));
     assert!(claim1.is_current_for("alice"));
     assert!(!claim0.is_current_for("bob"));
@@ -59,7 +60,7 @@ async fn exclusive() {
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim0.expiry - chrono::Duration::from_std(params.lease_duration).unwrap()
+        claim0.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap()
     );
     // Since we just acquired this, the acquire time and renew time are the
     // same.
@@ -111,7 +112,7 @@ async fn expires() {
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim1.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim1.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     // Since we just acquired this, the acquire time and renew time are the
     // same.
@@ -167,14 +168,14 @@ async fn renews() {
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim2.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim2.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     assert_time_eq!(
         rsrc.acquire_time
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim0.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim0.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     assert_eq!(
         time::Duration::from_secs(
@@ -210,14 +211,14 @@ async fn renews() {
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim3.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim3.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     assert_time_eq!(
         rsrc.acquire_time
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim3.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim3.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     assert_eq!(
         time::Duration::from_secs(
@@ -281,14 +282,14 @@ async fn vacate_expired_noop() {
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     assert_time_eq!(
         rsrc.acquire_time
             .as_ref()
             .map(|metav1::MicroTime(t)| t)
             .expect("renewTime"),
-        claim.expiry - chrono::Duration::from_std(params.lease_duration).unwrap(),
+        claim.expiry - jiff::SignedDuration::try_from(params.lease_duration).unwrap(),
     );
     assert_eq!(rsrc.lease_duration_seconds, Some(3));
     assert_eq!(rsrc.lease_transitions, Some(1));

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -76,7 +76,7 @@ initialized = [
 ]
 lease = [
     "dep:backon",
-    "dep:chrono",
+    "dep:jiff",
     "dep:futures-util",
     "dep:hyper",
     "dep:k8s-openapi",
@@ -115,7 +115,7 @@ runtime = [
     "shutdown",
 ]
 runtime-diagnostics = [
-    "dep:chrono",
+    "dep:jiff",
     "dep:serde_json",
     "dep:k8s-openapi",
     "dep:parking_lot",
@@ -184,9 +184,9 @@ ahash = { version = "0.8", optional = true }
 backon = { version = "1", optional = true, features = ["tokio-sleep"] }
 bytes = { version = "1", optional = true }
 drain = { version = "0.2.1", optional = true, default-features = false }
-chrono = { version = "0.4", optional = true, default-features = false }
 futures-core = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3", optional = true, default-features = false }
+jiff = { version = "0.2", optional = true, default-features = false }
 http-body-util = { version = "0.1", optional = true }
 hyper = { workspace = true, optional = true, default-features = false }
 hyper-util = { workspace = true, optional = true, default-features = false }

--- a/kubert/src/admin/diagnostics.rs
+++ b/kubert/src/admin/diagnostics.rs
@@ -12,7 +12,7 @@ use self::watch::WatchDiagnostics;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Diagnostics {
-    initial_time: chrono::DateTime<chrono::Utc>,
+    initial_time: jiff::Timestamp,
     watches: Arc<Mutex<Vec<watch::StateRef>>>,
     #[cfg(feature = "lease")]
     leases: Arc<Mutex<Vec<lease::StateRef>>>,
@@ -37,7 +37,7 @@ struct Summary {
 impl Diagnostics {
     pub(super) fn new() -> Self {
         Self {
-            initial_time: chrono::Utc::now(),
+            initial_time: jiff::Timestamp::now(),
             watches: Default::default(),
             #[cfg(feature = "lease")]
             leases: Default::default(),
@@ -81,7 +81,7 @@ impl Diagnostics {
         let leases = self.summarize_leases();
         let summary = Summary {
             initial_timestamp: Time(self.initial_time),
-            current_timestamp: Time(chrono::Utc::now()),
+            current_timestamp: Time(jiff::Timestamp::now()),
             watches,
             #[cfg(feature = "lease")]
             leases,

--- a/kubert/src/admin/diagnostics/lease.rs
+++ b/kubert/src/admin/diagnostics/lease.rs
@@ -54,7 +54,7 @@ impl LeaseDiagnostics {
             field_manager,
         }: &crate::LeaseParams,
     ) -> Self {
-        let now = Time(chrono::Utc::now());
+        let now = Time(jiff::Timestamp::now());
         Self(Arc::new(RwLock::new(LeaseState {
             name: name.clone(),
             namespace: namespace.clone(),
@@ -90,7 +90,7 @@ impl LeaseDiagnostics {
         {
             return;
         }
-        let now = Time(chrono::Utc::now());
+        let now = Time(jiff::Timestamp::now());
         state.current = claim
             .as_deref()
             .cloned()

--- a/kubert/src/admin/diagnostics/watch.rs
+++ b/kubert/src/admin/diagnostics/watch.rs
@@ -88,7 +88,7 @@ impl WatchDiagnostics {
             api_url: api_url.to_string(),
             label_selector: label_selector.unwrap_or_default().to_string(),
             stats: WatchStats {
-                creation_timestamp: Time(chrono::Utc::now()),
+                creation_timestamp: Time(jiff::Timestamp::now()),
                 errors: 0,
                 last_error: None,
                 resets: 0,
@@ -137,7 +137,7 @@ impl WatchDiagnostics {
             uid: meta.uid.clone().unwrap_or_default(),
         };
 
-        let now = Time(chrono::Utc::now());
+        let now = Time(jiff::Timestamp::now());
         let WatchState {
             ref mut known,
             ref mut resetting,

--- a/kubert/src/lease.rs
+++ b/kubert/src/lease.rs
@@ -7,6 +7,7 @@
 //! [`LeaseManager`] interacts with a [`coordv1::Lease`] resource to ensure that
 //! only a single claimant owns the lease at a time.
 
+use jiff::SpanRelativeTo;
 use k8s_openapi::{api::coordination::v1 as coordv1, apimachinery::pkg::apis::meta::v1 as metav1};
 use std::{borrow::Cow, sync::Arc};
 use tokio::time::{self, Duration};
@@ -70,7 +71,7 @@ pub struct Claim {
     pub holder: String,
 
     /// The time that the lease expires.
-    pub expiry: chrono::DateTime<chrono::Utc>,
+    pub expiry: jiff::Timestamp,
 }
 
 /// Indicates an error interacting with the Lease API
@@ -130,7 +131,7 @@ impl Claim {
     /// Returns true iff the claim is still valid according to the system clock
     #[inline]
     pub fn is_current(&self) -> bool {
-        chrono::Utc::now() < self.expiry
+        jiff::Timestamp::now() < self.expiry
     }
 
     /// Returns true iff the claim is still valid for the provided claimant
@@ -146,8 +147,10 @@ impl Claim {
 
     /// Waits until there is a grace period remaining before the claim expires
     pub async fn expire_with_grace(&self, grace: Duration) {
-        if let Ok(remaining) = (self.expiry - chrono::Utc::now()).to_std() {
-            let sleep = remaining.saturating_sub(grace);
+        if let Ok(remaining) =
+            (self.expiry - jiff::Timestamp::now()).to_duration(SpanRelativeTo::days_are_24_hours())
+        {
+            let sleep = remaining.unsigned_abs().saturating_sub(grace);
             if !sleep.is_zero() {
                 tokio::time::sleep(sleep).await;
             }
@@ -228,9 +231,9 @@ impl LeaseManager {
                 // renewing the claim.
                 if claim.holder == claimant {
                     let renew_at = claim.expiry
-                        - chrono::Duration::from_std(params.renew_grace_period)
-                            .unwrap_or_else(|_| chrono::Duration::zero());
-                    if chrono::Utc::now() < renew_at {
+                        - jiff::SignedDuration::try_from(params.renew_grace_period)
+                            .unwrap_or(jiff::SignedDuration::ZERO);
+                    if jiff::Timestamp::now() < renew_at {
                         return Ok(claim.clone());
                     }
 
@@ -437,9 +440,9 @@ impl LeaseManager {
         claimant: &str,
         params: &ClaimParams,
     ) -> Result<(Arc<Claim>, Meta), Error> {
-        let lease_duration =
-            chrono::Duration::from_std(params.lease_duration).unwrap_or(chrono::Duration::MAX);
-        let now = chrono::Utc::now();
+        let lease_duration = jiff::SignedDuration::try_from(params.lease_duration)
+            .unwrap_or(jiff::SignedDuration::MAX);
+        let now = jiff::Timestamp::now();
         let lease = self
             .patch(&kube_client::api::Patch::Apply(serde_json::json!({
                 "apiVersion": "coordination.k8s.io/v1",
@@ -451,7 +454,7 @@ impl LeaseManager {
                     "acquireTime": metav1::MicroTime(now),
                     "renewTime": metav1::MicroTime(now),
                     "holderIdentity": claimant,
-                    "leaseDurationSeconds": lease_duration.num_seconds(),
+                    "leaseDurationSeconds": lease_duration.as_secs(),
                     "leaseTransitions": meta.transitions + 1,
                 },
             })))
@@ -483,9 +486,9 @@ impl LeaseManager {
         claimant: &str,
         params: &ClaimParams,
     ) -> Result<(Arc<Claim>, Meta), Error> {
-        let lease_duration =
-            chrono::Duration::from_std(params.lease_duration).unwrap_or(chrono::Duration::MAX);
-        let now = chrono::Utc::now();
+        let lease_duration = jiff::SignedDuration::try_from(params.lease_duration)
+            .unwrap_or(jiff::SignedDuration::MAX);
+        let now = jiff::Timestamp::now();
         let lease = self
             .patch(&kube_client::api::Patch::Strategic(serde_json::json!({
                 "apiVersion": "coordination.k8s.io/v1",
@@ -495,7 +498,7 @@ impl LeaseManager {
                 },
                 "spec": {
                     "renewTime": metav1::MicroTime(now),
-                    "leaseDurationSeconds": lease_duration.num_seconds(),
+                    "leaseDurationSeconds": lease_duration.as_secs(),
                 },
             })))
             .await?;
@@ -567,9 +570,9 @@ impl LeaseManager {
 
         let metav1::MicroTime(renew_time) = or_unclaimed!(spec.renew_time);
         let lease_duration =
-            chrono::Duration::seconds(or_unclaimed!(spec.lease_duration_seconds).into());
+            jiff::SignedDuration::from_secs(or_unclaimed!(spec.lease_duration_seconds).into());
         let expiry = renew_time + lease_duration;
-        if expiry <= chrono::Utc::now() {
+        if expiry <= jiff::Timestamp::now() {
             return Ok(State { meta, claim: None });
         }
 
@@ -580,10 +583,9 @@ impl LeaseManager {
     }
 
     fn is_conflict(err: &Error) -> bool {
-        matches!(
-            err,
-            Error::Api(kube_client::Error::Api(kube_core::ErrorResponse { code, .. }))
-                if hyper::StatusCode::from_u16(*code).ok() == Some(hyper::StatusCode::CONFLICT)
-        )
+        let Error::Api(kube_client::Error::Api(s)) = err else {
+            return false;
+        };
+        hyper::StatusCode::from_u16(s.code).ok() == Some(hyper::StatusCode::CONFLICT)
     }
 }


### PR DESCRIPTION
This performs the following dependency updates:

`k8s-openapi`: 0.25 -> 0.27
`kube`: 1.1 -> 3
`kube-client`: 1.1 -> 3
`kube-core`: 1.1 -> 3
`kube-runtime`: 1.1 -> 3

These dependencies are farily tightly coupled, so must be updated together in a batch.

The most viral change in this PR is k8s-openapi trasitioning from `chrono` to `jiff` for timestamp/durations, other than that the changes have been relatively small.