### PR TITLE
chore(deps): Update MSRV to 1.88

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -158,8 +158,8 @@ jobs:
     strategy:
       matrix:
         rust:
+          - "1.92"
           - "1.88"
-          - "1.85"
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
@@ -290,8 +290,8 @@ jobs:
     strategy:
       matrix:
         rust:
+          - "1.92"
           - "1.88"
-          - "1.85"
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 publish = false
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [package.metadata.release]
 release = false

--- a/examples/watch_pods.rs
+++ b/examples/watch_pods.rs
@@ -183,7 +183,7 @@ async fn main() -> Result<()> {
 
         // If the watch stream completes, exit gracefully
         res = task => match res {
-            Err(error) => bail!("spawned task failed: {}", error),
+            Err(error) => bail!("spawned task failed: {error}"),
             Ok(Err(_)) => bail!("Timed out waiting for the first update"),
             Ok(Ok(())) => {
                 tracing::debug!("watch completed");

--- a/kubert-prometheus-process/Cargo.toml
+++ b/kubert-prometheus-process/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 description = "A prometheus-client process metrics collector"
 readme = "../README.md"
 repository = "https://github.com/olix0r/kubert"
-rust-version = "1.85"
+rust-version = "1.88"
 keywords = ["prometheus-client", "process", "metrics", "monitoring"]
 
 [dependencies]

--- a/kubert-prometheus-tokio/Cargo.toml
+++ b/kubert-prometheus-tokio/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 description = "A prometheus-client tokio runtime metrics collector"
 readme = "../README.md"
 repository = "https://github.com/olix0r/kubert"
-rust-version = "1.85"
+rust-version = "1.88"
 keywords = ["prometheus-client", "tokio", "metrics", "monitoring"]
 
 [features]

--- a/kubert/Cargo.toml
+++ b/kubert/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 description = "Kubernetes runtime helpers. Based on kube-rs."
 readme = "../README.md"
 repository = "https://github.com/olix0r/kubert"
-rust-version = "1.85"
+rust-version = "1.88"
 keywords = ["kubernetes", "client", "runtime", "server"]
 
 [features]

--- a/kubert/src/log.rs
+++ b/kubert/src/log.rs
@@ -13,10 +13,11 @@ pub use tracing_subscriber::util::TryInitError as LogInitError;
 
 /// Configures whether logs should be emitted in plaintext (the default) or as JSON-encoded
 /// messages
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(docsrs, doc(cfg(feature = "log")))]
 pub enum LogFormat {
     /// The default plaintext format
+    #[default]
     Plain,
 
     /// The JSON-encoded format
@@ -153,12 +154,6 @@ impl std::fmt::Display for LogFilter {
 }
 
 // === impl LogFormat ===
-
-impl Default for LogFormat {
-    fn default() -> Self {
-        Self::Plain
-    }
-}
 
 impl std::str::FromStr for LogFormat {
     type Err = InvalidLogFormat;


### PR DESCRIPTION
This is required for multiple upstream dependencies, most notably newer versions of `k8s-openapi` and `kube`.