### PR TITLE
chore(examples): update references to `sample_iter()`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,7 @@ jobs:
       actions: ${{ steps.actions.outputs.any_changed == 'true' }}
       cargo: ${{ steps.cargo.outputs.any_changed == 'true' }}
       deny: ${{ steps.deny.outputs.any_changed == 'true' }}
-      kubert: ${{ steps.kubert.outputs.any_changed == 'true' }}
+      kubert: ${{ true || steps.kubert.outputs.any_changed == 'true' }}
       kubert-prometheus-process: ${{ steps.kubert-prometheus-process.outputs.any_changed == 'true' }}
       kubert-prometheus-tokio: ${{ steps.kubert-prometheus-tokio.outputs.any_changed == 'true' }}
       rust: ${{ steps.rust.outputs.any_changed == 'true' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,7 @@ jobs:
       actions: ${{ steps.actions.outputs.any_changed == 'true' }}
       cargo: ${{ steps.cargo.outputs.any_changed == 'true' }}
       deny: ${{ steps.deny.outputs.any_changed == 'true' }}
-      kubert: ${{ true || steps.kubert.outputs.any_changed == 'true' }}
+      kubert: ${{ steps.kubert.outputs.any_changed == 'true' }}
       kubert-prometheus-process: ${{ steps.kubert-prometheus-process.outputs.any_changed == 'true' }}
       kubert-prometheus-tokio: ${{ steps.kubert-prometheus-tokio.outputs.any_changed == 'true' }}
       rust: ${{ steps.rust.outputs.any_changed == 'true' }}

--- a/examples/tests/lease.rs
+++ b/examples/tests/lease.rs
@@ -355,7 +355,7 @@ impl Handle {
     }
 
     fn rand_name(base: impl std::fmt::Display) -> String {
-        use rand::Rng;
+        use rand::RngExt as _;
 
         struct LowercaseAlphanumeric;
 


### PR DESCRIPTION
this was renamed in https://github.com/rust-random/rand/pull/1717.

this commit updates the lease examples to reflect this.

Signed-off-by: katelyn martin <kate@buoyant.io>
